### PR TITLE
FacebookRequestException now extends FacebookSDKException

### DIFF
--- a/src/Facebook/FacebookRequestException.php
+++ b/src/Facebook/FacebookRequestException.php
@@ -29,7 +29,7 @@ namespace Facebook;
  * @author Fosco Marotto <fjm@fb.com>
  * @author David Poll <depoll@fb.com>
  */
-class FacebookRequestException extends \Exception
+class FacebookRequestException extends FacebookSDKException
 {
 
   /**


### PR DESCRIPTION
Simple change but this will now allow a developer to catch all exceptions the SDK would throw by just catching `FacebookSDKException`.

So instead of forcing the developer to catch 2 exceptions every time like this:

``` php
try {
} catch (FacebookRequestException $e) {
} catch (FacebookSDKException $e) {
}
```

They can just do this and figure out what kind of exception was thrown from there.

``` php
try {
} catch (FacebookSDKException $e) {
}
```

This is useful for when using something like [Laravel's exception catch-all handler](http://laravel.com/docs/errors#handling-errors) that can be set up to catch all of the SDK's exceptions.
