### PR TITLE
Normalize the phpunit.xml file just a bit

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,8 +1,8 @@
 <phpunit bootstrap="bootstrap.php"
          stopOnFailure="true">
-    <testSuites>
+    <testsuites>
         <testsuite name="Facebook">
-            <directory>tests</directory>
+            <directory>.</directory>
         </testsuite>
-    </testSuites>
+    </testsuites>
 </phpunit>


### PR DESCRIPTION
Just wanted to normalize the phpunit.xml file. 
1. The xml tags are generally all lowercase, not camel case.
2. You are already in the tests directory, so the directory would be ., not tests.
