### PR TITLE
Extend FacebookRedirectLoginHelper storeState and loadState method

### DIFF
--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -48,14 +48,14 @@ class FacebookRedirectLoginHelper
   private $redirectUrl;
 
   /**
-   * @var string State token for CSRF validation
-   */
-  private $state;
-
-  /**
    * @var string Prefix to use for session variables
    */
   private $sessionPrefix = 'FBRLH_';
+
+  /**
+   * @var string State token for CSRF validation
+   */
+  protected $state;
 
 
   /**


### PR DESCRIPTION
Change $state property visibility to protected in order to use by
getSessionFromRedirect which call loadState method and set $state.
