### PR TITLE
Use PSR-0 loading instead of classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
         "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
-        "classmap": ["src"]
+        "psr-0": {
+            "Facebook\\": "src/"
+        }
     }
 }


### PR DESCRIPTION
As the SDK is now namespaced, it can load classes with the PSR-0 standard.

But...
Composer also support the new PSR-4. So we can move all classes from `src/Facebook/` to `src/` and remove a useless path level, without break anything !
