### PR TITLE
Checking for malformed signed request

### DIFF
--- a/src/Facebook/FacebookSession.php
+++ b/src/Facebook/FacebookSession.php
@@ -279,6 +279,10 @@ class FacebookSession
           'Invalid signed request, using wrong algorithm.'
         );
       }
+    } else {
+      throw new FacebookSDKException(
+        'Malformed signed request.'
+      );
     }
   }
 


### PR DESCRIPTION
In `FacebookSession.php` file, `private static function parseSignedRequest($signedRequest, $state)` method is missing `else` clause for `if` statement:

``` php
if (strpos($signedRequest, '.') !== false) {
```

It can result in sending requests to Graph API without access token because `parseSignedRequest` method will return `null` (because the `return` keyword is omitted) when malformed signed request is passed.

Added `else` statement.
