### PR TITLE
Added more specific handling for exceptions thrown by Graph

### DIFF
--- a/src/Facebook/FacebookRequestException.php
+++ b/src/Facebook/FacebookRequestException.php
@@ -82,19 +82,45 @@ class FacebookRequestException extends FacebookSDKException
     }
     $code = (isset($data['error']['code']) ? $data['error']['code'] : null);
 
-    // Login status or token expired, revoked, or invalid
-    if ($code == 102 || $code == 190 || $code == 100) {
-      return new FacebookAuthorizationException($raw, $data, $statusCode);
+    if (isset($data['error']['error_subcode'])) {
+      switch ($data['error']['error_subcode']) {
+        // Other authentication issues
+        case 458:
+        case 459:
+        case 460:
+        case 463:
+        case 464:
+        case 467:
+          return new FacebookAuthorizationException($raw, $data, $statusCode);
+          break;
+      }
     }
 
-    // Server issue, possible downtime
-    if ($code == 1 || $code == 2) {
-      return new FacebookServerException($raw, $data, $statusCode);
-    }
+    switch ($code) {
+      // Login status or token expired, revoked, or invalid
+      case 100:
+      case 102:
+      case 190:
+        return new FacebookAuthorizationException($raw, $data, $statusCode);
+        break;
 
-    // API Throttling
-    if ($code == 4 || $code == 17 || $code == 341) {
-      return new FacebookThrottleException($raw, $data, $statusCode);
+      // Server issue, possible downtime
+      case 1:
+      case 2:
+        return new FacebookServerException($raw, $data, $statusCode);
+        break;
+
+      // API Throttling
+      case 4:
+      case 17:
+      case 341:
+        return new FacebookThrottleException($raw, $data, $statusCode);
+        break;
+
+      // Duplicate Post
+      case 506:
+        return new FacebookClientException($raw, $data, $statusCode);
+        break;
     }
 
     // Missing Permissions
@@ -102,10 +128,12 @@ class FacebookRequestException extends FacebookSDKException
       return new FacebookPermissionException($raw, $data, $statusCode);
     }
 
-    // Duplicate Post
-    if ($code == 506) {
-      return new FacebookClientException($raw, $data, $statusCode);
+    // OAuth authentication error
+    if (isset($data['error']['type'])
+      and $data['error']['type'] === 'OAuthException') {
+      return new FacebookAuthorizationException($raw, $data, $statusCode);
     }
+
     // All others
     return new FacebookOtherException($raw, $data, $statusCode);
   }
@@ -128,7 +156,6 @@ class FacebookRequestException extends FacebookSDKException
    */
   public function getHttpStatusCode()
   {
-
     return $this->statusCode;
   }
 

--- a/tests/FacebookRequestExceptionTest.php
+++ b/tests/FacebookRequestExceptionTest.php
@@ -48,6 +48,38 @@ class FacebookRequestExceptionTest extends PHPUnit_Framework_TestCase
     $exception = FacebookRequestException::create($json, $params, 401);
     $this->assertTrue($exception instanceof FacebookAuthorizationException);
     $this->assertEquals(190, $exception->getCode());
+
+    $params['error']['type'] = 'OAuthException';
+    $params['error']['code'] = 0;
+    $params['error']['error_subcode'] = 458;
+    $json = json_encode($params);
+    $exception = FacebookRequestException::create($json, $params, 401);
+    $this->assertTrue($exception instanceof FacebookAuthorizationException);
+    $this->assertEquals(458, $exception->getSubErrorCode());
+
+    $params['error']['error_subcode'] = 460;
+    $json = json_encode($params);
+    $exception = FacebookRequestException::create($json, $params, 401);
+    $this->assertTrue($exception instanceof FacebookAuthorizationException);
+    $this->assertEquals(460, $exception->getSubErrorCode());
+
+    $params['error']['error_subcode'] = 463;
+    $json = json_encode($params);
+    $exception = FacebookRequestException::create($json, $params, 401);
+    $this->assertTrue($exception instanceof FacebookAuthorizationException);
+    $this->assertEquals(463, $exception->getSubErrorCode());
+
+    $params['error']['error_subcode'] = 467;
+    $json = json_encode($params);
+    $exception = FacebookRequestException::create($json, $params, 401);
+    $this->assertTrue($exception instanceof FacebookAuthorizationException);
+    $this->assertEquals(467, $exception->getSubErrorCode());
+
+    $params['error']['error_subcode'] = 0;
+    $json = json_encode($params);
+    $exception = FacebookRequestException::create($json, $params, 401);
+    $this->assertTrue($exception instanceof FacebookAuthorizationException);
+    $this->assertEquals(0, $exception->getSubErrorCode());
   }
 
   public function testServerExceptions()
@@ -108,6 +140,33 @@ class FacebookRequestExceptionTest extends PHPUnit_Framework_TestCase
     $exception = FacebookRequestException::create($json, $params, 401);
     $this->assertTrue($exception instanceof FacebookThrottleException);
     $this->assertEquals(341, $exception->getCode());
+  }
+
+  public function testUserIssueExceptions()
+  {
+    $params = array(
+      'error' => array(
+        'code' => 230,
+        'message' => 'errmsg',
+        'error_subcode' => 459,
+        'type' => 'exception'
+      )
+    );
+    $json = json_encode($params);
+    $exception = FacebookRequestException::create($json, $params, 401);
+    $this->assertTrue($exception instanceof FacebookAuthorizationException);
+    $this->assertEquals(230, $exception->getCode());
+    $this->assertEquals(459, $exception->getSubErrorCode());
+    $this->assertEquals('exception', $exception->getErrorType());
+    $this->assertEquals('errmsg', $exception->getMessage());
+    $this->assertEquals($json, $exception->getRawResponse());
+    $this->assertEquals(401, $exception->getHttpStatusCode());
+
+    $params['error']['error_subcode'] = 464;
+    $json = json_encode($params);
+    $exception = FacebookRequestException::create($json, $params, 401);
+    $this->assertTrue($exception instanceof FacebookAuthorizationException);
+    $this->assertEquals(464, $exception->getSubErrorCode());
   }
 
   public function testPermissionExceptions()


### PR DESCRIPTION
Added better handling of exceptions thrown by Graph.
1. Looks for error type `OAuthException` which Graph throws with undocumented error codes.
2. Looks at sub code and throws a new `FacebookUserIssueException` for codes 459 & 464. That way we can show a proper error message to the user telling them to go to Facebook and fix their beef.
