### PR TITLE
ETag support

### DIFF
--- a/src/Facebook/FacebookResponse.php
+++ b/src/Facebook/FacebookResponse.php
@@ -48,17 +48,31 @@ class FacebookResponse
   private $rawResponse;
 
   /**
+   * @var bool Indicates whether sent ETag matched the one on the FB side
+   */
+  private $etagHit;
+
+  /**
+   * @var string ETag received with the response. `null` in case of ETag hit.
+   */
+  private $etag;
+
+  /**
    * Creates a FacebookResponse object for a given request and response.
    *
    * @param FacebookRequest $request
    * @param array $responseData JSON Decoded response data
    * @param string $rawResponse Raw string response
+   * @param bool $etagHit Indicates whether sent ETag matched the one on the FB side
+   * @param string|null $etag ETag received with the response. `null` in case of ETag hit.
    */
-  public function __construct($request, $responseData, $rawResponse)
+  public function __construct($request, $responseData, $rawResponse, $etagHit = false, $etag = null)
   {
     $this->request = $request;
     $this->responseData = $responseData;
     $this->rawResponse = $rawResponse;
+    $this->etagHit = $etagHit;
+    $this->etag = $etag;
   }
 
   /**
@@ -89,6 +103,26 @@ class FacebookResponse
   public function getRawResponse()
   {
     return $this->rawResponse;
+  }
+
+  /**
+   * Returns true if ETag matched the one sent with a request
+   *
+   * @return bool
+   */
+  public function isETagHit()
+  {
+    return $this->etagHit;
+  }
+
+  /**
+   * Returns the ETag
+   *
+   * @return string
+   */
+  public function getETag()
+  {
+    return $this->etag;
   }
 
   /**

--- a/tests/ETagTest.php
+++ b/tests/ETagTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Facebook\FacebookRequest;
+
+class ETagTest extends PHPUnit_Framework_TestCase
+{
+
+  public static function setUpBeforeClass()
+  {
+    FacebookTestHelper::setUpBeforeClass();
+  }
+
+  public function testETagHit()
+  {
+    $response = (
+      new FacebookRequest(
+        FacebookTestHelper::$testSession,
+        'GET',
+        '/104048449631599'
+      ))->execute();
+
+    $response = (
+      new FacebookRequest(
+        FacebookTestHelper::$testSession,
+        'GET',
+        '/104048449631599',
+        null,
+        null,
+        $response->getETag()
+      ))->execute();
+
+    $this->assertTrue($response->isETagHit());
+    $this->assertNull($response->getETag());
+  }
+
+  public function testETagMiss()
+  {
+    $response = (
+      new FacebookRequest(
+        FacebookTestHelper::$testSession,
+        'GET',
+        '/104048449631599',
+        null,
+        null,
+        'someRandomValue'
+      ))->execute();
+
+    $this->assertFalse($response->isETagHit());
+    $this->assertNotNull($response->getETag());
+  }
+
+}


### PR DESCRIPTION
Adds [HTTP ETag](http://en.wikipedia.org/wiki/HTTP_ETag) support, proven solution to save a lot of network bandwidth. Usage:

``` php
// Send request with no ETag check
$response = (
  new FacebookRequest(
    FacebookTestHelper::$testSession,
    'GET',
    '/104048449631599'
  ))->execute();

// Save ETag for future use
$etag = $response->getETag();

// Send request **with** ETag check (6th FacebookRequest constructor parameter)
$response = (
  new FacebookRequest(
    FacebookTestHelper::$testSession,
    'GET',
    '/104048449631599',
    null,
    null,
    $etag
  ))->execute();

if ($response->isETagHit()) {
  // Content didn't change
} else {
  // Get a new ETag and cache a new content
  $etag = $response->getETag();
}
```

Tests can be found in `tests/ETagTest.php` file.
