### PR TITLE
[Bug Fix] Fixed bug that blindly appended params to a url

### DIFF
--- a/tests/FacebookRequestTest.php
+++ b/tests/FacebookRequestTest.php
@@ -22,4 +22,34 @@ class FacebookRequestTest extends PHPUnit_Framework_TestCase
     $this->assertNotNull($response->getProperty('name'));
   }
 
+  public function testGracefullyHandlesUrlAppending()
+  {
+    $params = array();
+    $url = 'https://www.foo.com/';
+    $processed_url = FacebookRequest::appendParamsToUrl($url, $params);
+    $this->assertEquals('https://www.foo.com/', $processed_url);
+
+    $params = array(
+      'access_token' => 'foo',
+    );
+    $url = 'https://www.foo.com/';
+    $processed_url = FacebookRequest::appendParamsToUrl($url, $params);
+    $this->assertEquals('https://www.foo.com/?access_token=foo', $processed_url);
+
+    $params = array(
+      'access_token' => 'foo',
+      'bar' => 'baz',
+    );
+    $url = 'https://www.foo.com/?foo=bar';
+    $processed_url = FacebookRequest::appendParamsToUrl($url, $params);
+    $this->assertEquals('https://www.foo.com/?access_token=foo&bar=baz&foo=bar', $processed_url);
+
+    $params = array(
+      'access_token' => 'foo',
+    );
+    $url = 'https://www.foo.com/?foo=bar&access_token=bar';
+    $processed_url = FacebookRequest::appendParamsToUrl($url, $params);
+    $this->assertEquals('https://www.foo.com/?access_token=bar&foo=bar', $processed_url);
+  }
+
 }


### PR DESCRIPTION
I should be able to pass `FacebookRequest` a URL that already has params appended to it like so:

``` php
$data = (new FacebookRequest(
    $session, 'GET', '/123/accounts/test-users?limit=10&fields=id,access_token,login_url'
  ))->execute();
```

But it will blindly append the access token and will return an ill-formed URL like this:

```
https://graph.facebook.com/v2.0/123/accounts/test-users?limit=10&fields=id,access_token,login_url?access_token=some_token
```

This PR fixes that. :)

I also fixed the doc blocks in this file.

I also made it so you can overwrite the default `access_token` via `$params`. Important for extensibility and testing. :)
