### PR TITLE
Added injectable persistent data handler

### DIFF
--- a/src/Facebook/FacebookContainer.php
+++ b/src/Facebook/FacebookContainer.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook;
+
+/**
+ * Class FacebookContainer
+ * @package Facebook
+ */
+class FacebookContainer
+{
+
+  /**
+   * @var FacebookPersistable Persistent data handler
+   */
+  private static $persistentDataHandler;
+
+  /**
+   * setPersistentDataHandler - Returns an instance of the persistent
+   * data handler
+   *
+   * @param FacebookPersistable
+   */
+  public static function setPersistentDataHandler(FacebookPersistable $handler)
+  {
+    static::$persistentDataHandler = $handler;
+  }
+
+  /**
+   * getPersistentDataHandler - Returns an instance of the persistent
+   * data handler
+   *
+   * @return FacebookPersistable
+   */
+  public static function getPersistentDataHandler()
+  {
+    if (isset(static::$persistentDataHandler)) return static::$persistentDataHandler;
+
+    return static::$persistentDataHandler = new FacebookPersistentDataHandler();
+  }
+
+}

--- a/src/Facebook/FacebookPersistable.php
+++ b/src/Facebook/FacebookPersistable.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook;
+
+/**
+ * Interface FacebookPersistable
+ * @package Facebook
+ */
+interface FacebookPersistable
+{
+
+  /**
+   * setPersistentData - Stores the given key-value pair, so that future
+   * calls to getPersistentData() for a given key return the related value.
+   *
+   * @param string $key   The name of the value we want to store
+   * @param mixed $value  The data we want to store
+   * @return void
+   */
+  public function setPersistentData($key, $value);
+
+  /**
+   * getPersistentData - Get the stored value for a given key which was
+   * set with setPersistentData().
+   *
+   * @param string $key     The name of the value we want to retrieve
+   * @param mixed $default  The default value that should be returned if
+   *                        the desired key does not exist
+   * @return mixed
+   */
+  public function getPersistentData($key, $default = null);
+
+}

--- a/src/Facebook/FacebookPersistentDataHandler.php
+++ b/src/Facebook/FacebookPersistentDataHandler.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook;
+
+/**
+ * Class FacebookPersistentDataHandler
+ * @package Facebook
+ */
+class FacebookPersistentDataHandler implements FacebookPersistable
+{
+
+  /**
+   * @var string Prefix to use for session variables
+   */
+  private $sessionPrefix = 'FBPDH_';
+
+  /**
+   * Creates a persistent data handler that interfaces with PHP's default
+   * session handling.
+   *
+   * @throws FacebookSDKException
+   */
+  public function __construct($ignoreSessionCheck = false)
+  {
+    if ($ignoreSessionCheck) {
+      return;
+    }
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+      throw new FacebookSDKException(
+        'Session not active. Unable to store persistent data.'
+      );
+    }
+  }
+
+  /**
+   * setPersistentData - Stores the given key-value pair, so that future
+   * calls to getPersistentData() for a given key return the related value.
+   *
+   * @param string $key   The name of the value we want to store
+   * @param mixed $value  The data we want to store
+   * @return void
+   */
+  public function setPersistentData($key, $value)
+  {
+    $_SESSION[$this->sessionPrefix . $key] = $value;
+  }
+
+  /**
+   * getPersistentData - Get the stored value for a given key which was
+   * set with setPersistentData().
+   *
+   * @param string $key     The name of the value we want to retrieve
+   * @param mixed $default  The default value that should be returned if
+   *                        the desired key does not exist
+   * @return mixed
+   */
+  public function getPersistentData($key, $default = null)
+  {
+    if (isset($_SESSION[$this->sessionPrefix . $key])) {
+      return $_SESSION[$this->sessionPrefix . $key];
+    }
+
+    return $default;
+  }
+
+}

--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -48,11 +48,6 @@ class FacebookRedirectLoginHelper
   private $redirectUrl;
 
   /**
-   * @var string Prefix to use for session variables
-   */
-  private $sessionPrefix = 'FBRLH_';
-
-  /**
    * @var string State token for CSRF validation
    */
   protected $state;
@@ -158,12 +153,7 @@ class FacebookRedirectLoginHelper
    */
   protected function storeState($state)
   {
-    if (session_status() !== PHP_SESSION_ACTIVE) {
-      throw new FacebookSDKException(
-        'Session not active, could not store state.'
-      );
-    }
-    $_SESSION[$this->sessionPrefix . 'state'] = $state;
+    FacebookContainer::getPersistentDataHandler()->setPersistentData('state', $state);
   }
 
   /**
@@ -176,16 +166,7 @@ class FacebookRedirectLoginHelper
    */
   protected function loadState()
   {
-    if (session_status() !== PHP_SESSION_ACTIVE) {
-      throw new FacebookSDKException(
-        'Session not active, could not load state.'
-      );
-    }
-    if (isset($_SESSION[$this->sessionPrefix . 'state'])) {
-      $this->state = $_SESSION[$this->sessionPrefix . 'state'];
-      return $this->state;
-    }
-    return null;
+    return FacebookContainer::getPersistentDataHandler()->getPersistentData('state');
   }
 
 }

--- a/tests/FacebookPersistentDataHandlerTest.php
+++ b/tests/FacebookPersistentDataHandlerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Facebook\FacebookPersistentDataHandler;
+
+class FacebookPersistentDataHandlerTest extends PHPUnit_Framework_TestCase
+{
+
+  public static function setUpBeforeClass()
+  {
+    FacebookTestHelper::setUpBeforeClass();
+  }
+
+  public function testCanSetAndGetPersistentData()
+  {
+    $handler = new FacebookPersistentDataHandler(true);
+
+    $handler->setPersistentData('foo', 'bar');
+    $this->assertEquals('bar', $_SESSION['FBPDH_foo']);
+
+    $data = $handler->getPersistentData('foo');
+    $this->assertEquals('bar', $data);
+
+    $dataWithDefault = $handler->getPersistentData('bar', 'baz');
+    $this->assertEquals('baz', $dataWithDefault);
+  }
+
+}

--- a/tests/FacebookRedirectLoginHelperTest.php
+++ b/tests/FacebookRedirectLoginHelperTest.php
@@ -10,13 +10,7 @@ class FacebookRedirectLoginHelperTest extends PHPUnit_Framework_TestCase
 
   public static function setUpBeforeClass()
   {
-    session_start();
     FacebookTestHelper::setUpBeforeClass();
-  }
-
-  public static function tearDownAfterClass()
-  {
-    session_destroy();
   }
 
   public function testLoginURL()

--- a/tests/FacebookTestHelper.php
+++ b/tests/FacebookTestHelper.php
@@ -3,6 +3,8 @@
 use Facebook\FacebookSession;
 use Facebook\FacebookRequest;
 use Facebook\FacebookSDKException;
+use Facebook\FacebookContainer;
+use Facebook\FacebookPersistable;
 
 class FacebookTestHelper
 {
@@ -20,6 +22,9 @@ class FacebookTestHelper
     }
     FacebookSession::setDefaultApplication(
       FacebookTestCredentials::$appId, FacebookTestCredentials::$appSecret
+    );
+    FacebookContainer::setPersistentDataHandler(
+      new FacebookPersistentDataHandlerTestHelper()
     );
     if (!(static::$testSession instanceof FacebookSession)) {
       static::$testSession = static::createTestSession();
@@ -57,6 +62,31 @@ class FacebookTestHelper
       $testUserPath,
       $params))->execute()->getGraphObject();
     return new FacebookSession($response->getProperty('access_token'));
+  }
+
+}
+
+/**
+ * Class FacebookTestPersistentDataHandler
+ * An in-memory persistent data handler for testing
+ */
+class FacebookPersistentDataHandlerTestHelper implements FacebookPersistable
+{
+
+  protected $session = array();
+
+  public function setPersistentData($key, $value)
+  {
+    $this->session[$key] = $value;
+  }
+
+  public function getPersistentData($key, $default = null)
+  {
+    if (isset($this->session[$key])) {
+      return $this->session[$key];
+    }
+
+    return $default;
   }
 
 }


### PR DESCRIPTION
This addresses one of the issues from #25.

Ideally the SDK would have some sort of Factory or service class that we could inject all the dependancies and configuration into. But since we don't have one, I added the injection setter to `FacebookSession` since it's a requirement for all Graph requests.

A developer can now inject their own persistent data handler. For example, here's a [Laravel](http://laravel.com/) implementation:

``` php
use Facebook\FacebookPersistable;
use Facebook\FacebookContainer;

class LaravelFacebookPersistentDataHandler implements FacebookPersistable
{
  public function setPersistentData($key, $value)
  {
    Session::put($key, $value);
  }

  public function getPersistentData($key, $default = null)
  {
    return Session::get($key, $default);
  }
}

FacebookContainer::setPersistentDataHandler(new LaravelFacebookPersistentDataHandler());
```

I think it'd be nice to have any extensible features documented in the README.
