### PR TITLE
Removed class member access on instatiaton

### DIFF
--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -133,12 +133,13 @@ class FacebookRedirectLoginHelper
           FacebookSession::_getTargetAppSecret($this->appSecret),
         'code' => $this->getCode()
       );
-      $response = (new FacebookRequest(
+      $instance = new FacebookRequest(
         FacebookSession::newAppSession($this->appId, $this->appSecret),
         'GET',
         '/oauth/access_token',
         $params
-      ))->execute()->getResponse();
+      );
+      $response = $instance->execute()->getResponse();
       if (isset($response['access_token'])) {
         return new FacebookSession($response['access_token']);
       }

--- a/src/Facebook/FacebookResponse.php
+++ b/src/Facebook/FacebookResponse.php
@@ -134,7 +134,8 @@ class FacebookResponse
    * @return mixed
    */
   public function getGraphObject($type = 'Facebook\GraphObject') {
-    return (new GraphObject($this->responseData))->cast($type);
+    $instance = new GraphObject($this->responseData);
+    return $instance->cast($type);
   }
 
   /**
@@ -149,7 +150,8 @@ class FacebookResponse
     $out = array();
     $data = $this->responseData->data;
     for ($i = 0; $i < count($data); $i++) {
-      $out[] = (new GraphObject($data[$i]))->cast($type);
+      $instance = new GraphObject($data[$i]);
+      $out[] = $instance->cast($type);
     }
     return $out;
   }

--- a/src/Facebook/FacebookSession.php
+++ b/src/Facebook/FacebookSession.php
@@ -83,14 +83,15 @@ class FacebookSession
   {
     $targetAppId = static::_getTargetAppId($appId);
     $targetAppSecret = static::_getTargetAppSecret($appSecret);
-    return (new FacebookRequest(
+    $instance = new FacebookRequest(
       static::newAppSession($targetAppId, $targetAppSecret),
       'GET',
       '/debug_token',
       array(
         'input_token' => $this->getToken(),
       )
-    ))->execute()->getGraphObject(GraphSessionInfo::className());
+    );
+    return $instance->execute()->getGraphObject(GraphSessionInfo::className());
   }
 
   /**
@@ -115,12 +116,13 @@ class FacebookSession
     );
     // The response for this endpoint is not JSON, so it must be handled
     //   differently, not as a GraphObject.
-    $response = (new FacebookRequest(
+    $instance = new FacebookRequest(
       self::newAppSession($targetAppId, $targetAppSecret),
       'GET',
       '/oauth/access_token',
       $params
-    ))->execute()->getResponse();
+    );
+    $response = $instance->execute()->getResponse();
     if ($response) {
       return new FacebookSession($response['access_token']);
     } else {
@@ -148,12 +150,13 @@ class FacebookSession
       'client_secret' => $targetAppSecret,
       'redirect_uri' => ''
     );
-    $response = (new FacebookRequest(
+    $instance = new FacebookRequest(
       self::newAppSession($targetAppId, $targetAppSecret),
       'GET',
       '/oauth/client_code',
       $params
-    ))->execute()->getGraphObject();
+    );
+    $response = $instance->execute()->getGraphObject();
     return $response->getProperty('code');
   }
 
@@ -238,13 +241,14 @@ class FacebookSession
         self::$defaultAppSecret,
       'code' => $parsedSignedRequest['code']
     );
-    $response = (new FacebookRequest(
+    $instance = new FacebookRequest(
       self::newAppSession(
         self::$defaultAppId, self::$defaultAppSecret),
       'GET',
       '/oauth/access_token',
       $params
-    ))->execute()->getResponse();
+    );
+    $response = $instance->execute()->getResponse();
     if (isset($response['access_token'])) {
       return new FacebookSession($response['access_token']);
     }

--- a/src/Facebook/GraphObject.php
+++ b/src/Facebook/GraphObject.php
@@ -104,7 +104,8 @@ class GraphObject
       if (is_scalar($value)) {
         return $value;
       } else {
-        return (new GraphObject($value))->cast($type);
+        $instance = new GraphObject($value);
+        return $instance->cast($type);
       }
     } else {
       return null;
@@ -138,7 +139,8 @@ class GraphObject
       if (is_scalar($value)) {
         $out[$key] = $value;
       } else {
-        $out[$key] = (new GraphObject($value))->cast($type);
+        $instance = new GraphObject($value);
+        $out[$key] = $instance->cast($type);
       }
     }
     return $out;

--- a/src/Facebook/GraphSessionInfo.php
+++ b/src/Facebook/GraphSessionInfo.php
@@ -61,7 +61,8 @@ class GraphSessionInfo extends GraphObject
   {
     $stamp = $this->getProperty('expires_at');
     if ($stamp) {
-      return (new \DateTime())->setTimestamp($stamp);
+      $instance = new \DateTime();
+      return $instance->setTimestamp($stamp);
     } else {
       return null;
     }
@@ -86,7 +87,8 @@ class GraphSessionInfo extends GraphObject
   {
     $stamp = $this->getProperty('issued_at');
     if ($stamp) {
-      return (new \DateTime())->setTimestamp($stamp);
+      $instance = new \DateTime();
+      return $instance->setTimestamp($stamp);
     } else {
       return null;
     }


### PR DESCRIPTION
PHP 5.3 doesn't allow accessing a class member (method or property) when
instantiating the class. Moving the `new` keyword to the above line
makes the SDK totally usable in that PHP version.

PHP 5.3 is still used in about 50% of the PHP-powered websites.

![screenshot_36](https://cloud.githubusercontent.com/assets/2876259/2962883/48f841e2-dad5-11e3-9ad7-b564c18315a0.png)
