### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+Contributing
+------------
+
+For us to accept contributions you will have to first have signed the
+[Contributor License Agreement](https://developers.facebook.com/opensource/cla).
+
+When committing, keep all lines to less than 80 characters, and try to
+follow the existing style.
+
+Before creating a pull request, squash your commits into a single commit.
+
+Add the comments where needed, and provide ample explanation in the
+commit message.


### PR DESCRIPTION
Github supports a number of special files, one of them being Contributing.md

Upon inclusion to your repo, your terms will always appear at the top of every
pull request reminding a user to review them.

In the case of all Facebook OSS work requiring an agreement to the CLA, this
would be a useful reminder to have.
