### PR TITLE
[Fix] Fixed warnings that would display when running tests

### DIFF
--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -58,6 +58,11 @@ class FacebookRedirectLoginHelper
   protected $state;
 
   /**
+   * @var boolean Toggle for PHP session status check
+   */
+  protected $checkForSessionStatus = true;
+
+  /**
    * Constructs a RedirectLoginHelper for a given appId and redirectUrl.
    *
    * @param string $redirectUrl The URL Facebook should redirect users to
@@ -178,7 +183,8 @@ class FacebookRedirectLoginHelper
    */
   protected function storeState($state)
   {
-    if (session_status() !== PHP_SESSION_ACTIVE) {
+    if ($this->checkForSessionStatus === true
+      && session_status() !== PHP_SESSION_ACTIVE) {
       throw new FacebookSDKException(
         'Session not active, could not store state.', 720
       );
@@ -197,7 +203,8 @@ class FacebookRedirectLoginHelper
    */
   protected function loadState()
   {
-    if (session_status() !== PHP_SESSION_ACTIVE) {
+    if ($this->checkForSessionStatus === true
+      && session_status() !== PHP_SESSION_ACTIVE) {
       throw new FacebookSDKException(
         'Session not active, could not load state.', 721
       );
@@ -207,6 +214,16 @@ class FacebookRedirectLoginHelper
       return $this->state;
     }
     return null;
+  }
+
+  /**
+   * Disables the session_status() check when using $_SESSION
+   *
+   * @return void
+   */
+  public function disableSessionStatusCheck()
+  {
+    $this->checkForSessionStatus = false;
   }
 
 }

--- a/tests/FacebookRedirectLoginHelperTest.php
+++ b/tests/FacebookRedirectLoginHelperTest.php
@@ -10,13 +10,7 @@ class FacebookRedirectLoginHelperTest extends PHPUnit_Framework_TestCase
 
   public static function setUpBeforeClass()
   {
-    session_start();
     FacebookTestHelper::setUpBeforeClass();
-  }
-
-  public static function tearDownAfterClass()
-  {
-    session_destroy();
   }
 
   public function testLoginURL()
@@ -26,6 +20,7 @@ class FacebookRedirectLoginHelperTest extends PHPUnit_Framework_TestCase
       FacebookTestCredentials::$appId,
       FacebookTestCredentials::$appSecret
     );
+    $helper->disableSessionStatusCheck();
     $loginUrl = $helper->getLoginUrl();
     $state = $_SESSION['FBRLH_state'];
     $params = array(
@@ -51,6 +46,7 @@ class FacebookRedirectLoginHelperTest extends PHPUnit_Framework_TestCase
       FacebookTestCredentials::$appId,
       FacebookTestCredentials::$appSecret
     );
+    $helper->disableSessionStatusCheck();
     $logoutUrl = $helper->getLogoutUrl(
       FacebookTestHelper::$testSession, self::REDIRECT_URL
     );


### PR DESCRIPTION
Now we can run tests without all the warnings about the PHP session.

Saving grace from #44.

Also closes #8 since we're not injecting persistent data handlers.
