### PR TITLE
Update FacebookRequest.php

### DIFF
--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -179,7 +179,7 @@ class FacebookRequest
     }
     $this->etag = $etag;
 
-    $params = ($parameters ?: array());
+    $params = ($parameters ? $parameters : array());
     if ($session
       && !isset($params["access_token"])) {
       $params["access_token"] = $session->getToken();


### PR DESCRIPTION
line 182
some servers don't accept this sugar syntactics
so sdk raise code 191 missing redirect_uri because $params returns empty array instead of the actual parameters for some reason...
so i fixed this sugar syntactics properly.
