### PR TITLE
Use consistent type for FacebookResponse::$responseData.

### DIFF
--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -240,16 +240,16 @@ class FacebookRequest
     $headers = $connection->getResponseHeaders();
     $etagReceived = isset($headers['ETag']) ? $headers['ETag'] : null;
 
-    $decodedResult = json_decode($result);
+    $decodedResult = json_decode($result, true);
     if ($decodedResult === null) {
       $out = array();
       parse_str($result, $out);
       return new FacebookResponse($this, $out, $result, $etagHit, $etagReceived);
     }
-    if (isset($decodedResult->error)) {
+    if (isset($decodedResult['error'])) {
       throw FacebookRequestException::create(
         $result,
-        $decodedResult->error,
+        $decodedResult['error'],
         $connection->getResponseHttpStatusCode()
       );
     }

--- a/src/Facebook/FacebookResponse.php
+++ b/src/Facebook/FacebookResponse.php
@@ -147,7 +147,7 @@ class FacebookResponse
    */
   public function getGraphObjectList($type = 'Facebook\GraphObject') {
     $out = array();
-    $data = $this->responseData->data;
+    $data = $this->responseData['data'];
     for ($i = 0; $i < count($data); $i++) {
       $out[] = (new GraphObject($data[$i]))->cast($type);
     }
@@ -184,8 +184,8 @@ class FacebookResponse
    * @return FacebookRequest|null
    */
   private function handlePagination($direction) {
-    if (isset($this->responseData->paging->$direction)) {
-      $url = parse_url($this->responseData->paging->$direction);
+    if (isset($this->responseData['paging'][$direction])) {
+      $url = parse_url($this->responseData['paging'][$direction]);
       parse_str($url['query'], $params);
 
       return new FacebookRequest(

--- a/tests/GraphObjectTest.php
+++ b/tests/GraphObjectTest.php
@@ -90,7 +90,7 @@ class GraphObjectTest extends PHPUnit_Framework_TestCase
       )
     );
     $enc = json_encode($backingData);
-    $response = new FacebookResponse(null, json_decode($enc), $enc);
+    $response = new FacebookResponse(null, json_decode($enc, true), $enc);
     $list = $response->getGraphObjectList(GraphUser::className());
     $this->assertEquals(2, count($list));
     $this->assertTrue($list[0] instanceof GraphObject);


### PR DESCRIPTION
When a FacebookResponse is instantiated by FacebookRequest, the responseData arg is either an object (if the response was json decoded), or an array (if response parsed with parse_str()). The PHPDoc comments define responseData as an array. For consistency, object (stdClass) usage is replaced with array.
