### PR TITLE
Enabled app secret proof by default

### DIFF
--- a/src/Facebook/FacebookSession.php
+++ b/src/Facebook/FacebookSession.php
@@ -55,7 +55,7 @@ class FacebookSession
   /**
    * @var bool
    */
-  private static $useAppSecretProof = false;
+  private static $useAppSecretProof = true;
 
   /**
    * When creating a Session from an access_token, use:

--- a/tests/FacebookRequestTest.php
+++ b/tests/FacebookRequestTest.php
@@ -120,6 +120,8 @@ class FacebookRequestTest extends PHPUnit_Framework_TestCase
 
   public function testAppSecretProof()
   {
+    $enableAppSecretProof = FacebookSession::useAppSecretProof();
+
     FacebookSession::enableAppSecretProof(true);
     $request = new FacebookRequest(
       FacebookTestHelper::$testSession,
@@ -135,7 +137,9 @@ class FacebookRequestTest extends PHPUnit_Framework_TestCase
       'GET',
       '/me'
     );
-    $this->assertTrue(!isset($request->getParameters()['appsecret_proof']));
+    $this->assertFalse(isset($request->getParameters()['appsecret_proof']));
+
+    FacebookSession::enableAppSecretProof($enableAppSecretProof);
   }
 
 }


### PR DESCRIPTION
The default behavior should be to send the app secret proof for better security out-of-the-box.

Tests will now pass if your test app has "App Secret Proof for Server API calls" enabled.

[This documentation](https://developers.facebook.com/docs/graph-api/securing-requests) states that:

> If you're using the official PHP SDK, the appsecret_proof parameter is automatically added.

This PR makes that a true statement.
