### PR TITLE
Added retrieval of app_data for Page Tab Apps

### DIFF
--- a/src/Facebook/FacebookPageTabHelper.php
+++ b/src/Facebook/FacebookPageTabHelper.php
@@ -111,6 +111,19 @@ class FacebookPageTabHelper extends FacebookCanvasLoginHelper
     }
     return null;
   }
+  
+  /**
+   * Returns the app_data if available.
+   *
+   * @return object|null
+   */
+  public function getAppData()
+  {
+    if (isset($this->parsedSignedRequest['app_data'])) {
+      return $this->parsedSignedRequest['app_data'];
+    }
+    return null;
+  }
 
   /**
    * Parses a signed request.


### PR DESCRIPTION
There was no support to retrieve the app_data parameter added to Page Tab URLs. This has been added into the FacebookPageTabHelper.php.
