### PR TITLE
Decoupled signed request handling

### DIFF
--- a/src/Facebook/Entities/SignedRequest.php
+++ b/src/Facebook/Entities/SignedRequest.php
@@ -1,0 +1,386 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Entities;
+
+use Facebook\FacebookSDKException;
+use Facebook\FacebookSession;
+
+/**
+ * Class SignedRequest
+ * @package Facebook
+ */
+class SignedRequest
+{
+
+  /**
+   * @var string
+   */
+  public $rawSignedRequest;
+
+  /**
+   * @var array
+   */
+  public $payload;
+
+  /**
+   * Instantiate a new SignedRequest entity.
+   *
+   * @param string|null $rawSignedRequest The raw signed request.
+   * @param string|null $state random string to prevent CSRF.
+   * @param string|null $appSecret
+   */
+  public function __construct($rawSignedRequest = null, $state = null, $appSecret = null)
+  {
+    if (!$rawSignedRequest) {
+      return;
+    }
+
+    $this->rawSignedRequest = $rawSignedRequest;
+    $this->payload = static::parse($rawSignedRequest, $state, $appSecret);
+  }
+
+  /**
+   * Returns the raw signed request data.
+   *
+   * @return string|null
+   */
+  public function getRawSignedRequest()
+  {
+    return $this->rawSignedRequest;
+  }
+
+  /**
+   * Returns the parsed signed request data.
+   *
+   * @return array|null
+   */
+  public function getPayload()
+  {
+    return $this->payload;
+  }
+
+  /**
+   * Returns a property from the signed request data if available.
+   *
+   * @param string $key
+   * @param mixed|null $default
+   *
+   * @return mixed|null
+   */
+  public function get($key, $default = null)
+  {
+    if (isset($this->payload[$key])) {
+      return $this->payload[$key];
+    }
+    return $default;
+  }
+
+  /**
+   * Returns user_id from signed request data if available.
+   *
+   * @return string|null
+   */
+  public function getUserId()
+  {
+    return $this->get('user_id');
+  }
+
+  /**
+   * Checks for OAuth data in the payload.
+   *
+   * @return boolean
+   */
+  public function hasOAuthData()
+  {
+    return isset($this->payload['oauth_token']) || isset($this->payload['code']);
+  }
+
+  /**
+   * Creates a signed request from an array of data.
+   *
+   * @param array $payload
+   * @param string|null $appSecret
+   *
+   * @return string
+   */
+  public static function make(array $payload, $appSecret = null)
+  {
+    $payload['algorithm'] = 'HMAC-SHA256';
+    $payload['issued_at'] = time();
+    $encodedPayload = static::base64UrlEncode(json_encode($payload));
+
+    $hashedSig = static::hashSignature($encodedPayload, $appSecret);
+    $encodedSig = static::base64UrlEncode($hashedSig);
+
+    return $encodedSig.'.'.$encodedPayload;
+  }
+
+  /**
+   * Validates and decodes a signed request and returns
+   * the payload as an array.
+   *
+   * @param string $signedRequest
+   * @param string|null $state
+   * @param string|null $appSecret
+   *
+   * @return array
+   */
+  public static function parse($signedRequest, $state = null, $appSecret = null)
+  {
+    list($encodedSig, $encodedPayload) = static::split($signedRequest);
+
+    // Signature validation
+    $sig = static::decodeSignature($encodedSig);
+    $hashedSig = static::hashSignature($encodedPayload, $appSecret);
+    static::validateSignature($hashedSig, $sig);
+
+    // Payload validation
+    $data = static::decodePayload($encodedPayload);
+    static::validateAlgorithm($data);
+    if ($state) {
+      static::validateCsrf($data, $state);
+    }
+
+    return $data;
+  }
+
+  /**
+   * Validates the format of a signed request.
+   *
+   * @param string $signedRequest
+   *
+   * @throws FacebookSDKException
+   */
+  public static function validateFormat($signedRequest)
+  {
+    if (strpos($signedRequest, '.') !== false) {
+      return;
+    }
+
+    throw new FacebookSDKException(
+      'Malformed signed request.', 606
+    );
+  }
+
+  /**
+   * Decodes a raw valid signed request.
+   *
+   * @param string $signedRequest
+   *
+   * @returns array
+   */
+  public static function split($signedRequest)
+  {
+    static::validateFormat($signedRequest);
+
+    return explode('.', $signedRequest, 2);
+  }
+
+  /**
+   * Decodes the raw signature from a signed request.
+   *
+   * @param string $encodedSig
+   *
+   * @returns string
+   *
+   * @throws FacebookSDKException
+   */
+  public static function decodeSignature($encodedSig)
+  {
+    $sig = static::base64UrlDecode($encodedSig);
+
+    if ($sig) {
+      return $sig;
+    }
+
+    throw new FacebookSDKException(
+      'Signed request has malformed encoded signature data.', 607
+    );
+  }
+
+  /**
+   * Decodes the raw payload from a signed request.
+   *
+   * @param string $encodedPayload
+   *
+   * @returns array
+   *
+   * @throws FacebookSDKException
+   */
+  public static function decodePayload($encodedPayload)
+  {
+    $payload = static::base64UrlDecode($encodedPayload);
+
+    if ($payload) {
+      $payload = json_decode($payload, true);
+    }
+
+    if (is_array($payload)) {
+      return $payload;
+    }
+
+    throw new FacebookSDKException(
+      'Signed request has malformed encoded payload data.', 607
+    );
+  }
+
+  /**
+   * Validates the algorithm used in a signed request.
+   *
+   * @param array $data
+   *
+   * @throws FacebookSDKException
+   */
+  public static function validateAlgorithm(array $data)
+  {
+    if (isset($data['algorithm']) && $data['algorithm'] === 'HMAC-SHA256') {
+      return;
+    }
+
+    throw new FacebookSDKException(
+      'Signed request is using the wrong algorithm.', 605
+    );
+  }
+
+  /**
+   * Hashes the signature used in a signed request.
+   *
+   * @param string $encodedData
+   * @param string|null $appSecret
+   *
+   * @return string
+   *
+   * @throws FacebookSDKException
+   */
+  public static function hashSignature($encodedData, $appSecret = null)
+  {
+    $hashedSig = hash_hmac(
+      'sha256', $encodedData, FacebookSession::_getTargetAppSecret($appSecret), $raw_output = true
+    );
+
+    if ($hashedSig) {
+      return $hashedSig;
+    }
+
+    throw new FacebookSDKException(
+      'Unable to hash signature from encoded payload data.', 602
+    );
+  }
+
+  /**
+   * Validates the signature used in a signed request.
+   *
+   * @param string $hashedSig
+   * @param string $sig
+   *
+   * @throws FacebookSDKException
+   */
+  public static function validateSignature($hashedSig, $sig)
+  {
+    if (mb_strlen($hashedSig) === mb_strlen($sig)) {
+      $validate = 0;
+      for ($i = 0; $i < mb_strlen($sig); $i++) {
+        $validate |= ord($hashedSig[$i]) ^ ord($sig[$i]);
+      }
+      if ($validate === 0) {
+        return;
+      }
+    }
+
+    throw new FacebookSDKException(
+      'Signed request has an invalid signature.', 602
+    );
+  }
+
+  /**
+   * Validates a signed request against CSRF.
+   *
+   * @param array $data
+   * @param string $state
+   *
+   * @throws FacebookSDKException
+   */
+  public static function validateCsrf(array $data, $state)
+  {
+    if (isset($data['state']) && $data['state'] === $state) {
+      return;
+    }
+
+    throw new FacebookSDKException(
+      'Signed request did not pass CSRF validation.', 604
+    );
+  }
+
+  /**
+   * Base64 decoding which replaces characters:
+   *   + instead of -
+   *   / instead of _
+   * @link http://en.wikipedia.org/wiki/Base64#URL_applications
+   *
+   * @param string $input base64 url encoded input
+   *
+   * @return string decoded string
+   */
+  public static function base64UrlDecode($input)
+  {
+    $urlDecodedBase64 = strtr($input, '-_', '+/');
+    static::validateBase64($urlDecodedBase64);
+    return base64_decode($urlDecodedBase64);
+  }
+
+  /**
+   * Base64 encoding which replaces characters:
+   *   + instead of -
+   *   / instead of _
+   * @link http://en.wikipedia.org/wiki/Base64#URL_applications
+   *
+   * @param string $input string to encode
+   *
+   * @return string base64 url encoded input
+   */
+  public static function base64UrlEncode($input)
+  {
+    return strtr(base64_encode($input), '+/', '-_');
+  }
+
+  /**
+   * Validates a base64 string.
+   *
+   * @param string $input base64 value to validate
+   *
+   * @throws FacebookSDKException
+   */
+  public static function validateBase64($input)
+  {
+    $pattern = '/^[a-zA-Z0-9\/\r\n+]*={0,2}$/';
+    if (preg_match($pattern, $input)) {
+      return;
+    }
+
+    throw new FacebookSDKException(
+      'Signed request contains malformed base64 encoding.', 608
+    );
+  }
+
+}

--- a/src/Facebook/FacebookCanvasLoginHelper.php
+++ b/src/Facebook/FacebookCanvasLoginHelper.php
@@ -29,52 +29,41 @@ namespace Facebook;
  * @author Fosco Marotto <fjm@fb.com>
  * @author David Poll <depoll@fb.com>
  */
-class FacebookCanvasLoginHelper
+class FacebookCanvasLoginHelper extends FacebookSignedRequestFromInputHelper
 {
 
   /**
-   * Gets a FacebookSession from the parameters passed by Facebook to a
-   *   Canvas POST request.
+   * Returns the app data value.
    *
-   * @throws FacebookSDKException
-   * @return FacebookSession|null
+   * @return mixed|null
    */
-  public function getSession()
+  public function getAppData()
   {
-    if ($signedRequest = $this->getSignedRequest()) {
-      try {
-        return FacebookSession::newSessionFromSignedRequest($signedRequest);
-      } catch (FacebookSDKException $ex) {
-        // Signed request is valid but user is not logged in.
-        if ($ex->getCode() == 603) {
-          return null;
-        }
-        throw $ex;
-      }
-    }
-    return null;
+    return $this->signedRequest ? $this->signedRequest->get('app_data') : null;
   }
 
   /**
-   * Get signed request.
+   * Get raw signed request from either GET or POST.
    *
    * @return string|null
    */
-  protected function getSignedRequest()
+  public function getRawSignedRequest()
   {
     /**
      * v2.0 apps use GET for Canvas signed requests.
      */
-    if (isset($_GET['signed_request'])) {
-      return $_GET['signed_request'];
+    $rawSignedRequest = $this->getRawSignedRequestFromGet();
+    if ($rawSignedRequest) {
+      return $rawSignedRequest;
     }
 
     /**
      * v1.0 apps use POST for Canvas signed requests, will eventually be
      * deprecated.
      */
-    if (isset($_POST['signed_request'])) {
-      return $_POST['signed_request'];
+    $rawSignedRequest = $this->getRawSignedRequestFromPost();
+    if ($rawSignedRequest) {
+      return $rawSignedRequest;
     }
 
     return null;

--- a/src/Facebook/FacebookJavaScriptLoginHelper.php
+++ b/src/Facebook/FacebookJavaScriptLoginHelper.php
@@ -29,54 +29,17 @@ namespace Facebook;
  * @author Fosco Marotto <fjm@fb.com>
  * @author David Poll <depoll@fb.com>
  */
-class FacebookJavaScriptLoginHelper
+class FacebookJavaScriptLoginHelper extends FacebookSignedRequestFromInputHelper
 {
 
-  private $appId;
-
   /**
-   * Creates a JavaScript Login Helper for the given application id, or the
-   *   default if not provided.
-   *
-   * @param string $appId
-   *
-   * @throws FacebookSDKException
-   */
-  public function __construct($appId = null)
-  {
-    $this->appId = FacebookSession::_getTargetAppId($appId);
-    if (!$this->appId) {
-      throw new FacebookSDKException(
-        'You must provide or set a default application id.', 700
-      );
-    }
-  }
-
-  /**
-   * Gets a FacebookSession from the cookies/params set by the Facebook
-   *   JavaScript SDK.
-   *
-   * @return FacebookSession|null
-   */
-  public function getSession()
-  {
-    if ($signedRequest = $this->getSignedRequest()) {
-      return FacebookSession::newSessionFromSignedRequest($signedRequest);
-    }
-    return null;
-  }
-
-  /**
-   * Get signed request
+   * Get raw signed request from the cookie.
    *
    * @return string|null
    */
-  protected function getSignedRequest()
+  public function getRawSignedRequest()
   {
-    if (isset($_COOKIE['fbsr_' . $this->appId])) {
-      return $_COOKIE['fbsr_' . $this->appId];
-    }
-    return null;
+    return $this->getRawSignedRequestFromCookie();
   }
 
 }

--- a/src/Facebook/FacebookPageTabHelper.php
+++ b/src/Facebook/FacebookPageTabHelper.php
@@ -32,143 +32,71 @@ class FacebookPageTabHelper extends FacebookCanvasLoginHelper
 {
 
   /**
-   * @var FacebookSession
-   */
-  public $session = null;
-
-  /**
    * @var array|null
    */
-  private $parsedSignedRequest = null;
+  protected $pageData;
 
   /**
-   * @var array|null
+   * Initialize the helper and process available signed request data.
+   *
+   * @param string|null $appId
+   * @param string|null $appSecret
    */
-  private $pageData = null;
-
-  /**
-   * Initialize the Page Tab helper and process available signed request data
-   */
-  public function __construct()
+  public function __construct($appId = null, $appSecret = null)
   {
-    $signedRequest = $this->getSignedRequest();
-    if ($signedRequest) {
-      $this->parsedSignedRequest = $this->parseSignedRequest($signedRequest);
-      if (isset($this->parsedSignedRequest['page'])) {
-        $this->pageData = $this->parsedSignedRequest['page'];
-      }
+    parent::__construct($appId, $appSecret);
+
+    if (!$this->signedRequest) {
+      return;
     }
+
+    $this->pageData = $this->signedRequest->get('page');
+  }
+
+  /**
+   * Returns a value from the page data.
+   *
+   * @param string $key
+   * @param mixed|null $default
+   *
+   * @return mixed|null
+   */
+  public function getPageData($key, $default = null)
+  {
+    if (isset($this->pageData[$key])) {
+      return $this->pageData[$key];
+    }
+    return $default;
   }
 
   /**
    * Returns true if the page is liked by the user.
    *
-   * @return bool
+   * @return boolean
    */
   public function isLiked()
   {
-    if (isset($this->pageData['liked']) && $this->pageData['liked'] == 'true') {
-      return true;
-    }
-    return false;
+    return $this->getPageData('liked') === true;
   }
 
   /**
    * Returns true if the user is an admin.
    *
-   * @return bool
+   * @return boolean
    */
   public function isAdmin()
   {
-    if (isset($this->pageData['admin']) && $this->pageData['admin'] == 'true') {
-      return true;
-    }
-    return false;
+    return $this->getPageData('admin') === true;
   }
 
   /**
    * Returns the page id if available.
    *
-   * @return int|null
+   * @return string|null
    */
   public function getPageId()
   {
-    if (isset($this->pageData['id'])) {
-      return $this->pageData['id'];
-    }
-    return null;
-  }
-
-  /**
-   * Returns the user_id if available.
-   *
-   * @return string|null
-   */
-  public function getUserId()
-  {
-    if (isset($this->parsedSignedRequest['user_id'])) {
-      return $this->parsedSignedRequest['user_id'];
-    }
-    return null;
-  }
-  
-  /**
-   * Returns the app_data if available.
-   *
-   * @return object|null
-   */
-  public function getAppData()
-  {
-    if (isset($this->parsedSignedRequest['app_data'])) {
-      return $this->parsedSignedRequest['app_data'];
-    }
-    return null;
-  }
-
-  /**
-   * Parses a signed request.
-   *
-   * @param string $signedRequest
-   *
-   * @return array
-   *
-   * @throws FacebookSDKException
-   */
-  private function parseSignedRequest($signedRequest)
-  {
-    if (strpos($signedRequest, '.') !== false) {
-      list($encodedSig, $encodedData) = explode('.', $signedRequest, 2);
-      $sig = FacebookSession::_base64UrlDecode($encodedSig);
-      $data = json_decode(FacebookSession::_base64UrlDecode($encodedData), true);
-      if (isset($data['algorithm']) && $data['algorithm'] === 'HMAC-SHA256') {
-        $expectedSig = hash_hmac(
-          'sha256', $encodedData, FacebookSession::_getTargetAppSecret(), true
-        );
-        if (strlen($sig) !== strlen($expectedSig)) {
-          throw new FacebookSDKException(
-            'Invalid signature on signed request.', 602
-          );
-        }
-        $validate = 0;
-        for ($i = 0; $i < strlen($sig); $i++) {
-          $validate |= ord($expectedSig[$i]) ^ ord($sig[$i]);
-        }
-        if ($validate !== 0) {
-          throw new FacebookSDKException(
-            'Invalid signature on signed request.', 602
-          );
-        }
-        return $data;
-      } else {
-        throw new FacebookSDKException(
-          'Invalid signed request, using wrong algorithm.', 605
-        );
-      }
-    } else {
-      throw new FacebookSDKException(
-        'Malformed signed request.', 606
-      );
-    }
+    return $this->getPageData('id');
   }
 
 }

--- a/src/Facebook/FacebookSignedRequestFromInputHelper.php
+++ b/src/Facebook/FacebookSignedRequestFromInputHelper.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook;
+
+use Facebook\Entities\SignedRequest;
+
+/**
+ * Class FacebookSignedRequestFromInputHelper
+ * @package Facebook
+ */
+abstract class FacebookSignedRequestFromInputHelper
+{
+
+  /**
+   * @var \Facebook\Entities\SignedRequest|null
+   */
+  protected $signedRequest;
+
+  /**
+   * @var string the app id
+   */
+  protected $appId;
+
+  /**
+   * @var string the app secret
+   */
+  protected $appSecret;
+
+  /**
+   * @var string|null Random string to prevent CSRF.
+   */
+  public $state = null;
+
+  /**
+   * Initialize the helper and process available signed request data.
+   *
+   * @param string|null $appId
+   * @param string|null $appSecret
+   */
+  public function __construct($appId = null, $appSecret = null)
+  {
+    $this->appId = FacebookSession::_getTargetAppId($appId);
+    $this->appSecret = FacebookSession::_getTargetAppSecret($appSecret);
+
+    $this->instantiateSignedRequest();
+  }
+
+  /**
+   * Instantiates a new SignedRequest entity.
+   *
+   * @param string|null
+   */
+  public function instantiateSignedRequest($rawSignedRequest = null)
+  {
+    $rawSignedRequest = $rawSignedRequest ?: $this->getRawSignedRequest();
+
+    if (!$rawSignedRequest) {
+      return;
+    }
+
+    $this->signedRequest = new SignedRequest($rawSignedRequest, $this->state, $this->appSecret);
+  }
+
+  /**
+   * Instantiates a FacebookSession from the signed request from input.
+   *
+   * @return FacebookSession|null
+   */
+  public function getSession()
+  {
+    if ($this->signedRequest && $this->signedRequest->hasOAuthData()) {
+      return FacebookSession::newSessionFromSignedRequest($this->signedRequest);
+    }
+    return null;
+  }
+
+  /**
+   * Returns the SignedRequest entity.
+   *
+   * @return \Facebook\Entities\SignedRequest|null
+   */
+  public function getSignedRequest()
+  {
+    return $this->signedRequest;
+  }
+
+  /**
+   * Returns the user_id if available.
+   *
+   * @return string|null
+   */
+  public function getUserId()
+  {
+    return $this->signedRequest ? $this->signedRequest->getUserId() : null;
+  }
+
+  /**
+   * Get raw signed request from input.
+   *
+   * @return string|null
+   */
+  abstract public function getRawSignedRequest();
+
+  /**
+   * Get raw signed request from GET input.
+   *
+   * @return string|null
+   */
+  public function getRawSignedRequestFromGet()
+  {
+    if (isset($_GET['signed_request'])) {
+      return $_GET['signed_request'];
+    }
+
+    return null;
+  }
+
+  /**
+   * Get raw signed request from POST input.
+   *
+   * @return string|null
+   */
+  public function getRawSignedRequestFromPost()
+  {
+    if (isset($_POST['signed_request'])) {
+      return $_POST['signed_request'];
+    }
+
+    return null;
+  }
+
+  /**
+   * Get raw signed request from cookie set from the Javascript SDK.
+   *
+   * @return string|null
+   */
+  public function getRawSignedRequestFromCookie()
+  {
+    if (isset($_COOKIE['fbsr_' . $this->appId])) {
+      return $_COOKIE['fbsr_' . $this->appId];
+    }
+    return null;
+  }
+
+}

--- a/tests/Entities/SignedRequestTest.php
+++ b/tests/Entities/SignedRequestTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use Facebook\Entities\SignedRequest;
+
+class SignedRequestTest extends PHPUnit_Framework_TestCase
+{
+
+  public $appSecret = 'foo_app_secret';
+
+  public $rawSignedRequest = 'U0_O1MqqNKUt32633zAkdd2Ce-jGVgRgJeRauyx_zC8=.eyJvYXV0aF90b2tlbiI6ImZvb190b2tlbiIsImFsZ29yaXRobSI6IkhNQUMtU0hBMjU2IiwiaXNzdWVkX2F0IjozMjEsImNvZGUiOiJmb29fY29kZSIsInN0YXRlIjoiZm9vX3N0YXRlIiwidXNlcl9pZCI6MTIzLCJmb28iOiJiYXIifQ==';
+
+  public $payloadData = array(
+    'oauth_token' => 'foo_token',
+    'algorithm' => 'HMAC-SHA256',
+    'issued_at' => 321,
+    'code' => 'foo_code',
+    'state' => 'foo_state',
+    'user_id' => 123,
+    'foo' => 'bar',
+  );
+
+  public function testValidSignedRequestsWillPassFormattingValidation()
+  {
+    $sr = SignedRequest::make($this->payloadData, $this->appSecret);
+    SignedRequest::validateFormat($sr);
+  }
+
+  /**
+   * @expectedException \Facebook\FacebookSDKException
+   */
+  public function testInvalidSignedRequestsWillFailFormattingValidation()
+  {
+    SignedRequest::validateFormat('invalid_signed_request');
+  }
+
+  public function testSignatureAndPayloadCanBeSeparatedInSignedRequests()
+  {
+    list($sig, $payload) = SignedRequest::split('sig.payload');
+
+    $this->assertEquals('sig', $sig);
+    $this->assertEquals('payload', $payload);
+  }
+
+  public function testBase64EncodingIsUrlSafe()
+  {
+    $encodedData = SignedRequest::base64UrlEncode('aijkoprstADIJKLOPQTUVX1256!)]-:;"<>?.|~');
+
+    $this->assertEquals('YWlqa29wcnN0QURJSktMT1BRVFVWWDEyNTYhKV0tOjsiPD4_Lnx-', $encodedData);
+  }
+
+  public function testAUrlSafeBase64EncodedStringCanBeDecoded()
+  {
+    $decodedData = SignedRequest::base64UrlDecode('YWlqa29wcnN0QURJSktMT1BRVFVWWDEyNTYhKV0tOjsiPD4/Lnx+');
+
+    $this->assertEquals('aijkoprstADIJKLOPQTUVX1256!)]-:;"<>?.|~', $decodedData);
+  }
+
+  public function testAValidEncodedSignatureCanBeDecoded()
+  {
+    $decodedSig = SignedRequest::decodeSignature('c2ln');
+
+    $this->assertEquals('sig', $decodedSig);
+  }
+
+  /**
+   * @expectedException \Facebook\FacebookSDKException
+   */
+  public function testAnImproperlyEncodedSignatureWillThrowAnException()
+  {
+    SignedRequest::decodeSignature('foo!');
+  }
+
+  public function testAValidEncodedPayloadCanBeDecoded()
+  {
+    $decodedPayload = SignedRequest::decodePayload('WyJwYXlsb2FkIl0=');
+
+    $this->assertEquals(array('payload'), $decodedPayload);
+  }
+
+  /**
+   * @expectedException \Facebook\FacebookSDKException
+   */
+  public function testAnImproperlyEncodedPayloadWillThrowAnException()
+  {
+    SignedRequest::decodePayload('foo!');
+  }
+
+  public function testSignedRequestDataMustContainTheHmacSha256Algorithm()
+  {
+    SignedRequest::validateAlgorithm($this->payloadData);
+  }
+
+  /**
+   * @expectedException \Facebook\FacebookSDKException
+   */
+  public function testNonApprovedAlgorithmsWillThrowAnException()
+  {
+    $signedRequestData = $this->payloadData;
+    $signedRequestData['algorithm'] = 'FOO-ALGORITHM';
+    SignedRequest::validateAlgorithm($signedRequestData);
+  }
+
+  public function testASignatureHashCanBeGeneratedFromBase64EncodedData()
+  {
+    $hashedSig = SignedRequest::hashSignature('WyJwYXlsb2FkIl0=', $this->appSecret);
+
+    $expectedSig = base64_decode('bFofyO2sERX73y8uvuX26SLodv0mZ+Zk18d8b3zhD+s=');
+    $this->assertEquals($expectedSig, $hashedSig);
+  }
+
+  public function testTwoBinaryStringsCanBeComparedForSignatureValidation()
+  {
+    $hashedSig = base64_decode('bFofyO2sERX73y8uvuX26SLodv0mZ+Zk18d8b3zhD+s=');
+    SignedRequest::validateSignature($hashedSig, $hashedSig);
+  }
+
+  /**
+   * @expectedException \Facebook\FacebookSDKException
+   */
+  public function testNonSameBinaryStringsWillThrowAnExceptionForSignatureValidation()
+  {
+    $hashedSig1 = base64_decode('bFofyO2sERX73y8uvuX26SLodv0mZ+Zk18d8b3zhD+s=');
+    $hashedSig2 = base64_decode('GJy4HzkRtCeZA0cJjdZJtGfovcdxgl/AERI20S4MY7c=');
+    SignedRequest::validateSignature($hashedSig1, $hashedSig2);
+  }
+
+  public function testASignedRequestWillPassCsrfValidation()
+  {
+    SignedRequest::validateCsrf($this->payloadData, 'foo_state');
+  }
+
+  /**
+   * @expectedException \Facebook\FacebookSDKException
+   */
+  public function testASignedRequestWithIncorrectCsrfDataWillThrowAnException()
+  {
+    SignedRequest::validateCsrf($this->payloadData, 'invalid_foo_state');
+  }
+
+  public function testARawSignedRequestCanBeValidatedAndDecoded()
+  {
+    $payload = SignedRequest::parse($this->rawSignedRequest, 'foo_state', $this->appSecret);
+
+    $this->assertEquals($this->payloadData, $payload);
+  }
+
+  public function testARawSignedRequestCanBeInjectedIntoTheConstructorToInstantiateANewEntity()
+  {
+    $signedRequest = new SignedRequest($this->rawSignedRequest, 'foo_state', $this->appSecret);
+
+    $rawSignedRequest = $signedRequest->getRawSignedRequest();
+    $payloadData = $signedRequest->getPayload();
+    $userId = $signedRequest->getUserId();
+    $hasOAuthData = $signedRequest->hasOAuthData();
+
+    $this->assertInstanceOf('\Facebook\Entities\SignedRequest', $signedRequest);
+    $this->assertEquals($this->rawSignedRequest, $rawSignedRequest);
+    $this->assertEquals($this->payloadData, $payloadData);
+    $this->assertEquals(123, $userId);
+    $this->assertTrue($hasOAuthData);
+  }
+
+}

--- a/tests/FacebookCanvasLoginHelperTest.php
+++ b/tests/FacebookCanvasLoginHelperTest.php
@@ -1,39 +1,34 @@
 <?php
 
 use Facebook\FacebookCanvasLoginHelper;
-use Facebook\FacebookSession;
 
 class FacebookCanvasLoginHelperTest extends PHPUnit_Framework_TestCase
 {
 
-  public function testGetSessionFromCanvasGET() {
-    $helper = new FacebookCanvasLoginHelper();
-    $signedRequest = FacebookSessionTest::makeSignedRequest(array(
-      'oauth_token' => 'token'
-    ));
-    $_GET['signed_request'] = $signedRequest;
-    $session = $helper->getSession();
-    $this->assertTrue($session instanceof FacebookSession);
-    $this->assertTrue($session->getToken() == 'token');
+  public $rawSignedRequestAuthorized = 'vdZXlVEQ5NTRRTFvJ7Jeo_kP4SKnBDvbNP0fEYKS0Sg=.eyJvYXV0aF90b2tlbiI6ImZvb190b2tlbiIsImFsZ29yaXRobSI6IkhNQUMtU0hBMjU2IiwiaXNzdWVkX2F0IjoxNDAyNTUxMDMxLCJ1c2VyX2lkIjoiMTIzIn0=';
+  protected $helper;
+
+  public function setUp()
+  {
+    $this->helper = new FacebookCanvasLoginHelper('123', 'foo_app_secret');
   }
 
-  public function testGetSessionFromCanvasPOST() {
-    $helper = new FacebookCanvasLoginHelper();
-    $signedRequest = FacebookSessionTest::makeSignedRequest(array(
-      'oauth_token' => 'token'
-    ));
-    $_POST['signed_request'] = $signedRequest;
-    $session = $helper->getSession();
-    $this->assertTrue($session instanceof FacebookSession);
-    $this->assertTrue($session->getToken() == 'token');
+  public function testSignedRequestDataCanBeRetrievedFromGetData()
+  {
+    $_GET['signed_request'] = $this->rawSignedRequestAuthorized;
+
+    $rawSignedRequest = $this->helper->getRawSignedRequest();
+
+    $this->assertEquals($this->rawSignedRequestAuthorized, $rawSignedRequest);
   }
 
-  public function testLoggedOutCanvasSession() {
-    $helper = new FacebookCanvasLoginHelper();
-    $signedRequest = FacebookSessionTest::makeSignedRequest(array(
-      'ship' => 'love'
-    ));
-    $_GET['signed_request'] = $signedRequest;
-    $this->assertNull($helper->getSession());
+  public function testSignedRequestDataCanBeRetrievedFromPostData()
+  {
+    $_POST['signed_request'] = $this->rawSignedRequestAuthorized;
+
+    $rawSignedRequest = $this->helper->getRawSignedRequest();
+
+    $this->assertEquals($this->rawSignedRequestAuthorized, $rawSignedRequest);
   }
+
 }

--- a/tests/FacebookJavaScriptLoginHelperTest.php
+++ b/tests/FacebookJavaScriptLoginHelperTest.php
@@ -1,22 +1,23 @@
 <?php
 
 use Facebook\FacebookJavaScriptLoginHelper;
-use Facebook\FacebookSession;
 
 class FacebookJavaScriptLoginHelperTest extends PHPUnit_Framework_TestCase
 {
 
-  public function testGetSessionFromCookie() {
-    $helper = new FacebookJavaScriptLoginHelper(
-      FacebookTestCredentials::$appId
-    );
-    $signedRequest = FacebookSessionTest::makeSignedRequest(array(
-      'oauth_token' => 'token'
-    ));
-    $_COOKIE['fbsr_' . FacebookTestCredentials::$appId] = $signedRequest;
-    $session = $helper->getSession();
-    $this->assertTrue($session instanceof FacebookSession);
-    $this->assertTrue($session->getToken() == 'token');
+  public $appId = '123';
+  public $appSecret = 'foo_app_secret';
+  public $rawSignedRequestAuthorized = 'vdZXlVEQ5NTRRTFvJ7Jeo_kP4SKnBDvbNP0fEYKS0Sg=.eyJvYXV0aF90b2tlbiI6ImZvb190b2tlbiIsImFsZ29yaXRobSI6IkhNQUMtU0hBMjU2IiwiaXNzdWVkX2F0IjoxNDAyNTUxMDMxLCJ1c2VyX2lkIjoiMTIzIn0=';
+
+  public function testARawSignedRequestCanBeRetrievedFromCookieData()
+  {
+    $_COOKIE['fbsr_123'] = $this->rawSignedRequestAuthorized;
+
+    $helper = new FacebookJavaScriptLoginHelper($this->appId, $this->appSecret);
+
+    $rawSignedRequest = $helper->getRawSignedRequest();
+
+    $this->assertEquals($this->rawSignedRequestAuthorized, $rawSignedRequest);
   }
 
 }

--- a/tests/FacebookPageTabHelperTest.php
+++ b/tests/FacebookPageTabHelperTest.php
@@ -1,65 +1,22 @@
 <?php
 
 use Facebook\FacebookPageTabHelper;
-use Facebook\FacebookSession;
 
 class FacebookPageTabHelperTest extends PHPUnit_Framework_TestCase
 {
 
-  public function testGetSessionFromPageTabGET() {
-    $signedRequest = FacebookSessionTest::makeSignedRequest(array(
-      'oauth_token' => 'token',
-      'page' => array(
-        'liked' => 'true',
-        'admin' => 'false',
-        'id' => 42
-      ),
-      'user_id' => '42'
-    ));
-    $_GET['signed_request'] = $signedRequest;
-    $helper = new FacebookPageTabHelper();
-    $session = $helper->getSession();
-    $this->assertTrue($session instanceof FacebookSession);
-    $this->assertTrue($session->getToken() == 'token');
+  protected $rawSignedRequestAuthorized = '6Hi26ECjkj347belC0O8b8H5lwiIz5eA6V9VVjTg-HU=.eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsImlzc3VlZF9hdCI6MzIxLCJvYXV0aF90b2tlbiI6ImZvb190b2tlbiIsInVzZXJfaWQiOiIxMjMiLCJwYWdlIjp7ImlkIjoiNDIiLCJsaWtlZCI6dHJ1ZSwiYWRtaW4iOmZhbHNlfX0=';
+
+  public function testPageDataCanBeAccessed()
+  {
+    $_GET['signed_request'] = $this->rawSignedRequestAuthorized;
+    $helper = new FacebookPageTabHelper('123', 'foo_app_secret');
+
     $this->assertTrue($helper->isLiked());
     $this->assertFalse($helper->isAdmin());
-    $this->assertEquals(42, $helper->getPageId());
-    $this->assertEquals('42', $helper->getUserId());
-  }
-
-  public function testGetSessionFromPageTabPOST() {
-    $signedRequest = FacebookSessionTest::makeSignedRequest(array(
-      'oauth_token' => 'token',
-      'page' => array(
-        'liked' => 'true',
-        'admin' => 'false',
-        'id' => 42
-      )    ));
-    $_POST['signed_request'] = $signedRequest;
-    $helper = new FacebookPageTabHelper();
-    $session = $helper->getSession();
-    $this->assertTrue($session instanceof FacebookSession);
-    $this->assertTrue($session->getToken() == 'token');
-    $this->assertTrue($helper->isLiked());
-    $this->assertFalse($helper->isAdmin());
-    $this->assertEquals(42, $helper->getPageId());
-  }
-
-  public function testLoggedOutPageTab() {
-    $signedRequest = FacebookSessionTest::makeSignedRequest(array(
-      'page' => array(
-        'liked' => 'false',
-        'admin' => 'true',
-        'id' => 42
-      )
-    ));
-    $_POST['signed_request'] = $signedRequest;
-    $helper = new FacebookPageTabHelper();
-    $session = $helper->getSession();
-    $this->assertNull($session);
-    $this->assertFalse($helper->isLiked());
-    $this->assertTrue($helper->isAdmin());
-    $this->assertEquals(42, $helper->getPageId());
+    $this->assertEquals('42', $helper->getPageId());
+    $this->assertEquals('42', $helper->getPageData('id'));
+    $this->assertEquals('default', $helper->getPageData('foo', 'default'));
   }
 
 }

--- a/tests/FacebookSignedRequestFromInputHelperTest.php
+++ b/tests/FacebookSignedRequestFromInputHelperTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Facebook\FacebookSignedRequestFromInputHelper;
+
+class FooSignedRequestHelper extends FacebookSignedRequestFromInputHelper {
+  public function getRawSignedRequest() {
+    return null;
+  }
+}
+
+class FacebookSignedRequestFromInputHelperTest extends PHPUnit_Framework_TestCase
+{
+
+  protected $helper;
+  public $rawSignedRequestAuthorized = 'vdZXlVEQ5NTRRTFvJ7Jeo_kP4SKnBDvbNP0fEYKS0Sg=.eyJvYXV0aF90b2tlbiI6ImZvb190b2tlbiIsImFsZ29yaXRobSI6IkhNQUMtU0hBMjU2IiwiaXNzdWVkX2F0IjoxNDAyNTUxMDMxLCJ1c2VyX2lkIjoiMTIzIn0=';
+  public $rawSignedRequestUnauthorized = 'KPlyhz-whtYAhHWr15N5TkbS_avz-2rUJFpFkfXKC88=.eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsImlzc3VlZF9hdCI6MTQwMjU1MTA4Nn0=';
+
+  public function setUp()
+  {
+    $this->helper = new FooSignedRequestHelper('123', 'foo_app_secret');
+  }
+
+  public function testSignedRequestDataCanBeRetrievedFromGetData()
+  {
+    $_GET['signed_request'] = 'foo_signed_request';
+
+    $rawSignedRequest = $this->helper->getRawSignedRequestFromGet();
+
+    $this->assertEquals('foo_signed_request', $rawSignedRequest);
+  }
+
+  public function testSignedRequestDataCanBeRetrievedFromPostData()
+  {
+    $_POST['signed_request'] = 'foo_signed_request';
+
+    $rawSignedRequest = $this->helper->getRawSignedRequestFromPost();
+
+    $this->assertEquals('foo_signed_request', $rawSignedRequest);
+  }
+
+  public function testSignedRequestDataCanBeRetrievedFromCookieData()
+  {
+    $_COOKIE['fbsr_123'] = 'foo_signed_request';
+
+    $rawSignedRequest = $this->helper->getRawSignedRequestFromCookie();
+
+    $this->assertEquals('foo_signed_request', $rawSignedRequest);
+  }
+
+  public function testSessionWillBeNullWhenAUserHasNotYetAuthorizedTheApp()
+  {
+    $this->helper->instantiateSignedRequest($this->rawSignedRequestUnauthorized);
+    $session = $this->helper->getSession();
+
+    $this->assertNull($session);
+  }
+
+  public function testAFacebookSessionCanBeInstantiatedWhenAUserHasAuthorizedTheApp()
+  {
+    $this->helper->instantiateSignedRequest($this->rawSignedRequestAuthorized);
+    $session = $this->helper->getSession();
+
+    $this->assertInstanceOf('Facebook\FacebookSession', $session);
+    $this->assertEquals('foo_token', $session->getToken());
+  }
+
+}


### PR DESCRIPTION
This PR completely decouples all the signed request handling from `FacebookSession`, `FacebookCanvasLoginHelper`, `FacebookPageTabHelper`, and `FacebookJavaScriptLoginHelper`.

Now we can handle signed requests directly. For example, signed requests are `POST`ed to a callback that you can set in your app setting when a user deauthorizes your app. So with this refactor you can do this on that callback URL:

``` php
use Facebook\Entities\SignedRequest;

$signedRequest = new SignedRequest($_POST['signed_request']);

$parsedSignedRequest = $signedRequest->getPayload();
$userId = $signedRequest->getUserId();
$someData = $signedRequest->get('some_other_data');
```

And if a `FacebookSession` was created from a signed request, you can access the entity like so:

``` php
$signedRequest = $session->getSignedRequest();

$userId = $signedRequest->getUserId();
// . . .
```
1. The next step is to decouple access token handling with a `Facebook\Entities\AccessToken` entity.
2. Once this PR gets pulled in, I'm going to submit a PR that refactors the tests a bit. Check out the format of the method names in the tests that are included in this PR. It's way more readable and isolated. I want to do this throughout the test suite. I also want to properly handle creating and destroying the test user that is created when running the tests. Currently I have a ton of `PHPUnitTestUser`'s in my test app.
