### PR TITLE
Problem with user picture resource into GraphObject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.phar
 .idea/
 tests/FacebookTestCredentials.php
 
+/nbproject

--- a/src/Facebook/GraphObject.php
+++ b/src/Facebook/GraphObject.php
@@ -51,6 +51,9 @@ class GraphObject
 
     if (isset($this->backingData['data']) && count($this->backingData) === 1) {
       $this->backingData = $this->backingData['data'];
+      if ($this->backingData instanceof \stdClass) {
+        $this->backingData = get_object_vars($this->backingData);
+      }
     }
   }
 
@@ -73,7 +76,7 @@ class GraphObject
       return new $type($this->backingData);
     } else {
       throw new FacebookSDKException(
-        'Cannot cast to an object that is not a GraphObject subclass', 620
+      'Cannot cast to an object that is not a GraphObject subclass', 620
       );
     }
   }


### PR DESCRIPTION
The end point data from user picture resource in Graph API (https://developers.facebook.com/docs/graph-api/reference/v2.0/user/picture/) is pushed into "data" key insted into root (I don't know why, is it correct?). \Facebook\GraphObject object from this response is creating wrong, property "backingData" is an instance of \stdClass insted an array and all of the methods that operate on this property as an array throw a fatal error "Cannot use object of type stdClass as array". This commit fix the issue.
