### PR TITLE
Added test user garbage collection to test suite

### DIFF
--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -87,6 +87,11 @@ class FacebookRequest
   private static $httpClientHandler;
 
   /**
+   * @var int The number of calls that have been made to Graph.
+   */
+  public static $requestCount = 0;
+
+  /**
    * getSession - Returns the associated FacebookSession.
    *
    * @return FacebookSession
@@ -241,6 +246,8 @@ class FacebookRequest
     // Should throw `FacebookSDKException` exception on HTTP client error.
     // Don't catch to allow it to bubble up.
     $result = $connection->send($url, $this->method, $params);
+
+    static::$requestCount++;
 
     $etagHit = 304 == $connection->getResponseHttpStatusCode();
 

--- a/tests/FacebookCanvasLoginHelperTest.php
+++ b/tests/FacebookCanvasLoginHelperTest.php
@@ -6,16 +6,6 @@ use Facebook\FacebookSession;
 class FacebookCanvasLoginHelperTest extends PHPUnit_Framework_TestCase
 {
 
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
-
-  public static function tearDownAfterClass()
-  {
-
-  }
-
   public function testGetSessionFromCanvasGET() {
     $helper = new FacebookCanvasLoginHelper();
     $signedRequest = FacebookSessionTest::makeSignedRequest(array(

--- a/tests/FacebookJavaScriptLoginHelperTest.php
+++ b/tests/FacebookJavaScriptLoginHelperTest.php
@@ -6,16 +6,6 @@ use Facebook\FacebookSession;
 class FacebookJavaScriptLoginHelperTest extends PHPUnit_Framework_TestCase
 {
 
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
-
-  public static function tearDownAfterClass()
-  {
-
-  }
-
   public function testGetSessionFromCookie() {
     $helper = new FacebookJavaScriptLoginHelper(
       FacebookTestCredentials::$appId
@@ -28,4 +18,5 @@ class FacebookJavaScriptLoginHelperTest extends PHPUnit_Framework_TestCase
     $this->assertTrue($session instanceof FacebookSession);
     $this->assertTrue($session->getToken() == 'token');
   }
+
 }

--- a/tests/FacebookPageTabHelperTest.php
+++ b/tests/FacebookPageTabHelperTest.php
@@ -6,16 +6,6 @@ use Facebook\FacebookSession;
 class FacebookPageTabHelperTest extends PHPUnit_Framework_TestCase
 {
 
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
-
-  public static function tearDownAfterClass()
-  {
-
-  }
-
   public function testGetSessionFromPageTabGET() {
     $signedRequest = FacebookSessionTest::makeSignedRequest(array(
       'oauth_token' => 'token',

--- a/tests/FacebookRedirectLoginHelperTest.php
+++ b/tests/FacebookRedirectLoginHelperTest.php
@@ -8,11 +8,6 @@ class FacebookRedirectLoginHelperTest extends PHPUnit_Framework_TestCase
 
   const REDIRECT_URL = 'http://invalid.zzz';
 
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
-
   public function testLoginURL()
   {
     $helper = new FacebookRedirectLoginHelper(

--- a/tests/FacebookRequestExceptionTest.php
+++ b/tests/FacebookRequestExceptionTest.php
@@ -12,11 +12,6 @@ use Facebook\FacebookSession;
 class FacebookRequestExceptionTest extends PHPUnit_Framework_TestCase
 {
 
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
-
   public function testAuthorizationExceptions()
   {
     $params = array(

--- a/tests/FacebookRequestTest.php
+++ b/tests/FacebookRequestTest.php
@@ -6,11 +6,6 @@ use Facebook\FacebookSession;
 class FacebookRequestTest extends PHPUnit_Framework_TestCase
 {
 
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
-
   public function testGetsTheLoggedInUsersProfile()
   {
     $response = (

--- a/tests/FacebookSessionTest.php
+++ b/tests/FacebookSessionTest.php
@@ -6,11 +6,6 @@ use Facebook\GraphSessionInfo;
 class FacebookSessionTest extends PHPUnit_Framework_TestCase
 {
 
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
-
   public function testSessionToken()
   {
     $session = new FacebookSession(FacebookTestHelper::getAppToken());

--- a/tests/FacebookTestHelper.php
+++ b/tests/FacebookTestHelper.php
@@ -4,24 +4,13 @@ use Facebook\FacebookSession;
 use Facebook\FacebookRequest;
 use Facebook\FacebookSDKException;
 
-// Uncomment two lines to force functional test curl implementation
-//use Facebook\HttpClients\FacebookCurlHttpClient;
-//FacebookRequest::setHttpClientHandler(new FacebookCurlHttpClient());
-
-// Uncomment two lines to force functional test stream wrapper implementation
-//use Facebook\HttpClients\FacebookStreamHttpClient;
-//FacebookRequest::setHttpClientHandler(new FacebookStreamHttpClient());
-
-// Uncomment two lines to force functional test Guzzle implementation
-//use Facebook\HttpClients\FacebookGuzzleHttpClient;
-//FacebookRequest::setHttpClientHandler(new FacebookGuzzleHttpClient());
-
 class FacebookTestHelper
 {
 
   public static $testSession;
+  protected static $testUserId;
 
-  public static function setUpBeforeClass()
+  public static function initialize()
   {
     if (!strlen(FacebookTestCredentials::$appId) ||
       !strlen(FacebookTestCredentials::$appSecret)) {
@@ -32,47 +21,53 @@ class FacebookTestHelper
     FacebookSession::setDefaultApplication(
       FacebookTestCredentials::$appId, FacebookTestCredentials::$appSecret
     );
-    if (!(static::$testSession instanceof FacebookSession)) {
+    if (!static::$testSession instanceof FacebookSession) {
       static::$testSession = static::createTestSession();
     }
   }
 
-  public static function setUp()
-  {
-
-  }
-
-  public static function tearDownAfterClass()
-  {
-
-  }
-
-  public static function tearDown()
-  {
-
-  }
-
   public static function createTestSession()
+  {
+    $accessToken = static::createTestUserAndGetAccessToken();
+    return new FacebookSession($accessToken);
+  }
+
+  public static function createTestUserAndGetAccessToken()
   {
     $testUserPath = '/' . FacebookTestCredentials::$appId . '/accounts/test-users';
     $params = array(
       'installed' => true,
-      'name' => 'PHPUnitTestUser',
+      'name' => 'Foo Phpunit User',
       'locale' => 'en_US',
-      'permissions' => 'read_stream, user_photos',
-      'method' => 'post'
+      'permissions' => 'read_stream,user_photos',
     );
-    $response = (new FacebookRequest(
-      new FacebookSession(FacebookTestHelper::getAppToken()),
-      'GET',
-      $testUserPath,
-      $params))->execute()->getGraphObject();
-    return new FacebookSession($response->getProperty('access_token'));
+
+    $request = new FacebookRequest(static::getAppSession(), 'POST', $testUserPath, $params);
+    $response = $request->execute()->getGraphObject();
+
+    static::$testUserId = $response->getProperty('id');
+
+    return $response->getProperty('access_token');
+  }
+
+  public static function getAppSession()
+  {
+    return new FacebookSession(static::getAppToken());
   }
 
   public static function getAppToken()
   {
     return FacebookTestCredentials::$appId . '|' . FacebookTestCredentials::$appSecret;
+  }
+
+  public static function deleteTestUser()
+  {
+    if (!static::$testUserId) {
+      return;
+    }
+    $testUserPath = '/' . static::$testUserId;
+    $request = new FacebookRequest(static::getAppSession(), 'DELETE', $testUserPath);
+    $request->execute();
   }
 
 }

--- a/tests/GraphAlbumTest.php
+++ b/tests/GraphAlbumTest.php
@@ -5,13 +5,9 @@ use Facebook\GraphAlbum;
 
 class GraphAlbumTest extends PHPUnit_Framework_TestCase
 {
+
   const ALBUM_DESCRIPTION = "Album Description";
   const ALBUM_NAME = "Album Name";
-
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
 
   public function testMeReturnsGraphAlbum()
   {
@@ -53,4 +49,5 @@ class GraphAlbumTest extends PHPUnit_Framework_TestCase
     $this->assertTrue($response->getCreatedTime() instanceof DateTime);
     $this->assertTrue($response->getUpdatedTime() instanceof DateTime);
   }
+
 }

--- a/tests/GraphLocationTest.php
+++ b/tests/GraphLocationTest.php
@@ -3,15 +3,9 @@
 use Facebook\FacebookRequest;
 use Facebook\GraphLocation;
 use Facebook\GraphObject;
-use Facebook\FacebookSession;
 
 class GraphLocationTest extends PHPUnit_Framework_TestCase
 {
-
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
 
   public function testLocation()
   {

--- a/tests/GraphObjectTest.php
+++ b/tests/GraphObjectTest.php
@@ -8,11 +8,6 @@ use Facebook\GraphUser;
 class GraphObjectTest extends PHPUnit_Framework_TestCase
 {
 
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
-
   public function testFriends()
   {
     $response = (

--- a/tests/GraphSessionInfoTest.php
+++ b/tests/GraphSessionInfoTest.php
@@ -7,11 +7,6 @@ use Facebook\FacebookSession;
 class GraphSessionInfoTest extends PHPUnit_Framework_TestCase
 {
 
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
-
   public function testSessionInfo()
   {
     $params = array(

--- a/tests/GraphUserTest.php
+++ b/tests/GraphUserTest.php
@@ -2,15 +2,9 @@
 
 use Facebook\FacebookRequest;
 use Facebook\GraphUser;
-use Facebook\FacebookSession;
 
 class GraphUserTest extends PHPUnit_Framework_TestCase
 {
-
-  public static function setUpBeforeClass()
-  {
-    FacebookTestHelper::setUpBeforeClass();
-  }
 
   public function testMeReturnsGraphUser()
   {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,5 +13,23 @@ if (!file_exists(__DIR__ . '/FacebookTestCredentials.php')) {
 require_once __DIR__ . '/FacebookTestCredentials.php';
 require_once __DIR__ . '/FacebookTestHelper.php';
 
-$baseDir = str_replace('/tests', '', __DIR__);
-define('APPLICATION_PATH', $baseDir);
+// Uncomment two lines to force functional test curl implementation
+//use Facebook\HttpClients\FacebookCurlHttpClient;
+//FacebookRequest::setHttpClientHandler(new FacebookCurlHttpClient());
+
+// Uncomment two lines to force functional test stream wrapper implementation
+//use Facebook\HttpClients\FacebookStreamHttpClient;
+//FacebookRequest::setHttpClientHandler(new FacebookStreamHttpClient());
+
+// Uncomment two lines to force functional test Guzzle implementation
+//use Facebook\HttpClients\FacebookGuzzleHttpClient;
+//FacebookRequest::setHttpClientHandler(new FacebookGuzzleHttpClient());
+
+// Create a temp test user to use for testing
+FacebookTestHelper::initialize();
+
+// Delete the temp test user after all tests have fired
+register_shutdown_function(function ()
+{
+  FacebookTestHelper::deleteTestUser();
+});


### PR DESCRIPTION
Cleaned up the test suite a bit and added garbage collection of the test user so that our apps don't get maxed out with phpunit test users as was happening in my app.

![Too many test users](https://cloud.githubusercontent.com/assets/578780/3279593/f42363f0-f405-11e3-85cb-eedc178c7b90.png)

I also added a tiny tweak to `FacebookRequests` that tracks the number of requests made to Graph. This is great for debugging. The test suite makes 21 calls to Graph right now FYI. :)

I didn't refactor the tests as much as I wanted to since I didn't want to cause any conflicts with #114. So after that one gets merged, I'll send another PR with a better test refactor. And one goal will be to try and decrease the number of requests made to Graph with each test run. :)
