### PR TITLE
Type hinting generates better error messages when an invalid session is ...

### DIFF
--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -112,7 +112,7 @@ class FacebookRedirectLoginHelper
    *
    * @return string
    */
-  public function getLogoutUrl($session, $next)
+  public function getLogoutUrl(FacebookSession $session, $next)
   {
     $params = array(
       'next' => $next,

--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -179,7 +179,7 @@ class FacebookRequest
    * @param string|null $etag
    */
   public function __construct(
-    $session, $method, $path, $parameters = null, $version = null, $etag = null
+    FacebookSession $session, $method, $path, $parameters = null, $version = null, $etag = null
   )
   {
     $this->session = $session;


### PR DESCRIPTION
...supplied

Otherwise if a different object or null is supplied, the Facebook request constructor throws an undefined index on the session object.
