### PR TITLE
Explicitly set arg separator to "&" in http_build_query calls.

### DIFF
--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -100,7 +100,7 @@ class FacebookRedirectLoginHelper
       'scope' => implode(',', $scope)
     );
     return 'https://www.facebook.com/' . $version . '/dialog/oauth?' .
-      http_build_query($params);
+      http_build_query($params, null, '&');
   }
 
   /**
@@ -118,7 +118,7 @@ class FacebookRedirectLoginHelper
       'next' => $next,
       'access_token' => $session->getToken()
     );
-    return 'https://www.facebook.com/logout.php?' . http_build_query($params);
+    return 'https://www.facebook.com/logout.php?' . http_build_query($params, null, '&');
   }
 
   /**

--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -298,7 +298,7 @@ class FacebookRequest
     }
 
     if (strpos($url, '?') === false) {
-      return $url . '?' . http_build_query($params);
+      return $url . '?' . http_build_query($params, null, '&');
     }
 
     list($path, $query_string) = explode('?', $url, 2);
@@ -307,7 +307,7 @@ class FacebookRequest
     // Favor params from the original URL over $params
     $params = array_merge($params, $query_array);
 
-    return $path . '?' . http_build_query($params);
+    return $path . '?' . http_build_query($params, null, '&');
   }
 
 }

--- a/src/Facebook/HttpClients/FacebookStreamHttpClient.php
+++ b/src/Facebook/HttpClients/FacebookStreamHttpClient.php
@@ -112,7 +112,7 @@ class FacebookStreamHttpClient implements FacebookHttpable {
     );
 
     if ($parameters) {
-      $options['http']['content'] = http_build_query($parameters);
+      $options['http']['content'] = http_build_query($parameters, null, '&');
 
       $this->addRequestHeader('Content-type', 'application/x-www-form-urlencoded');
     }


### PR DESCRIPTION
The value of "arg_separator.output" ini setting is used as separator by default, what causes the SDK to not work properly on PHP installations where "arg_separator.output" is set to anything else then "&".
- http://www.php.net//manual/en/function.http-build-query.php
