### PR TITLE
Added autoloader for those poor non-composer peeps

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/**
+ * You only need this file if you are not using composer.
+ * Why are you not using composer?
+ * https://getcomposer.org/
+ */
+
+if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+  throw new Exception('The Facebook SDK v4 requires PHP version 5.4 or higher.');
+}
+
+/**
+ * Register the autoloader for the Facebook SDK classes.
+ * Based off the official PSR-4 autoloader example found here:
+ * https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader-examples.md
+ *
+ * @param string $class The fully-qualified class name.
+ * @return void
+ */
+spl_autoload_register(function ($class)
+{
+  // project-specific namespace prefix
+  $prefix = 'Facebook\\';
+
+  // base directory for the namespace prefix
+  $base_dir = defined('FACEBOOK_SDK_V4_SRC_DIR') ? FACEBOOK_SDK_V4_SRC_DIR : __DIR__ . '/src/Facebook/';
+
+  // does the class use the namespace prefix?
+  $len = strlen($prefix);
+  if (strncmp($prefix, $class, $len) !== 0) {
+    // no, move to the next registered autoloader
+    return;
+  }
+
+  // get the relative class name
+  $relative_class = substr($class, $len);
+
+  // replace the namespace prefix with the base directory, replace namespace
+  // separators with directory separators in the relative class name, append
+  // with .php
+  $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+
+  // if the file exists, require it
+  if (file_exists($file)) {
+    require $file;
+  }
+});


### PR DESCRIPTION
# Usage

If you don't have composer, you can still autoload the SDK like so:

``` php
require __DIR__ . '/path/to/facebook-php-sdk-v4/autoload.php';
```

It should detect the `src/` folder automagically for you. If not you can define a constant with the path to the source files before the include.

``` php
define('FACEBOOK_SDK_V4_SRC_DIR', '/path/to/facebook-php-sdk-v4/src/Facebook/');
require __DIR__ . '/path/to/facebook-php-sdk-v4/autoload.php';
```

Also threw in a little PHP version check in there since that seems to be a recurring issue. People are getting syntax errors on < 5.4 and don't get a clear error message saying they need 5.4 or greater.

I didn't add this info the the README since the composer installation stuff wasn't there either, so maybe we could add it to the official documentation?
