### PR TITLE
Redirect login helper

### DIFF
--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -296,7 +296,7 @@ class FacebookRedirectLoginHelper
    * 
    * @todo Support Windows platforms
    */
-  public function random($bytes)
+  private function random($bytes)
   {
     if (!is_numeric($bytes)) {
       throw new FacebookSDKException(

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -111,7 +111,12 @@ class FacebookRedirectLoginHelperTest extends PHPUnit_Framework_TestCase
       FacebookTestCredentials::$appId,
       FacebookTestCredentials::$appSecret
     );
-	$this->assertEquals(1, preg_match('/^([0-9a-f]+)$/', $helper->random(32)));
+    
+    $class = new ReflectionClass('Facebook\\Helpers\\FacebookRedirectLoginHelper');
+    $method = $class->getMethod('random');
+    $method->setAccessible(true);
+
+    $this->assertEquals(1, preg_match('/^([0-9a-f]+)$/', $method->invoke($helper, 32)));
   }
 
 }


### PR DESCRIPTION
- Extract URI filtering feature in a dedicated function, allow overide of `getCurrentUri()` to not use global vars
- Add filtering of Facebook params if the user decline the login
- Maker `appId` and  `appSecret` available to children classes
- Allow an other state generation algorithm
- Make `random()` private as it only concern the helper
