### PR TITLE
AccessToken additions

### DIFF
--- a/src/Facebook/Entities/AccessToken.php
+++ b/src/Facebook/Entities/AccessToken.php
@@ -118,6 +118,21 @@ class AccessToken implements \Serializable
   }
 
   /**
+   * Checks the expiration of the access token.
+   *
+   * @return boolean|null
+   */
+  public function isExpired()
+  {
+    if ($this->getExpiresAt() instanceof \DateTime) {
+      return $this->getExpiresAt()->getTimestamp() < time();
+    }
+
+    // Not all access tokens return an expiration. E.g. an app access token.
+    return false;
+  }
+
+  /**
    * Checks the validity of the access token.
    *
    * @param string|null $appId Application ID to use

--- a/tests/Entities/AccessTokenTest.php
+++ b/tests/Entities/AccessTokenTest.php
@@ -253,4 +253,23 @@ class AccessTokenTest extends PHPUnit_Framework_TestCase
     $this->assertEquals($accessToken->getExpiresAt(), $newAccessToken->getExpiresAt());
     $this->assertEquals($accessToken->getMachineId(), $newAccessToken->getMachineId());
   }
+
+  /**
+   * @dataProvider provideAccessTokenExpiration
+   */
+  public function testIsExpired($expiresAt, $expected)
+  {
+    $accessToken = new AccessToken('foo', $expiresAt);
+
+    $this->assertEquals($expected, $accessToken->isExpired());
+  }
+
+  public function provideAccessTokenExpiration()
+  {
+    return array(
+      array(time()+60, false),
+      array(time()-60, true),
+      array(0, false),
+    );
+  }
 }


### PR DESCRIPTION
- It now serializable, as it the main credential data to call graph, it should be storable.

I have a problem with `isValid()`, I think sometimes you want check validity only with expires, without made an addition Graph API call to `/debug_token`.
I propose to have two access token classes:
- a `SimpleAccessToken` class like the current one, without full validity checks
- an `AccessToken` class than extends above one, and perform the graph call in constructor, and have accessors to all new useful data like user ID, scope, ... that are deeply associated to the access token.

About naming, I'm not sure, it can be `AccessToken` for the simple one and `FullAccessToken` for the second one.

@gfosco, @SammyK some thoughts ?
