### PR TITLE
Recognize https behind a proxy

### DIFF
--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -269,7 +269,11 @@ class FacebookRedirectLoginHelper
     if (isset($_SERVER['HTTPS']) &&
         ($_SERVER['HTTPS'] === 'on' || $_SERVER['HTTPS'] == 1)
         || isset($_SERVER['SERVER_PORT']) &&
-        ($_SERVER['SERVER_PORT'] === '443')) {
+        ($_SERVER['SERVER_PORT'] === '443')
+        || isset($_SERVER['HTTP_X_FORWARDED_PROTO']) &&
+        ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
+        || isset($_SERVER['HTTP_X_FORWARDED_PORT']) &&
+        ($_SERVER['HTTP_X_FORWARDED_PORT'] === '443')) {
       $scheme = 'https';
     }
     return $scheme;


### PR DESCRIPTION
Fix problem when the web server is behind an ssl termination proxy (http://en.wikipedia.org/wiki/SSL_termination_proxy)
