### PR TITLE
Fix Mockery

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,4 +16,9 @@
             <directory suffix=".php">./src/Facebook</directory>
         </whitelist>
     </filter>
+    <listeners>
+        <listener class="\Mockery\Adapter\Phpunit\TestListener"
+                  file="vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php">
+        </listener>
+    </listeners>
 </phpunit>

--- a/tests/Entities/AccessTokenTest.php
+++ b/tests/Entities/AccessTokenTest.php
@@ -31,11 +31,6 @@ use Facebook\Tests\FacebookTestHelper;
 class AccessTokenTest extends \PHPUnit_Framework_TestCase
 {
 
-  public function tearDown()
-  {
-    m::close();
-  }
-
   public function testAnAccessTokenCanBeReturnedAsAString()
   {
     $accessToken = new AccessToken('foo_token');

--- a/tests/FacebookSessionTest.php
+++ b/tests/FacebookSessionTest.php
@@ -31,11 +31,6 @@ use Facebook\Tests\FacebookTestHelper;
 class FacebookSessionTest extends \PHPUnit_Framework_TestCase
 {
 
-  public function tearDown()
-  {
-    m::close();
-  }
-
   public function testSessionToken()
   {
     $session = new FacebookSession(FacebookTestHelper::getAppToken());

--- a/tests/HttpClients/FacebookCurlHttpClientTest.php
+++ b/tests/HttpClients/FacebookCurlHttpClientTest.php
@@ -46,7 +46,6 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
 
   public function tearDown()
   {
-    m::close();
     (new FacebookCurlHttpClient()); // Resets the static dependency injection
   }
 

--- a/tests/HttpClients/FacebookGuzzleHttpClientTest.php
+++ b/tests/HttpClients/FacebookGuzzleHttpClientTest.php
@@ -43,7 +43,6 @@ class FacebookGuzzleHttpClientTest extends AbstractTestHttpClient
 
   public function tearDown()
   {
-    m::close();
     (new FacebookGuzzleHttpClient()); // Resets the static dependency injection
   }
 

--- a/tests/HttpClients/FacebookStreamHttpClientTest.php
+++ b/tests/HttpClients/FacebookStreamHttpClientTest.php
@@ -43,7 +43,6 @@ class FacebookStreamHttpClientTest extends AbstractTestHttpClient
 
   public function tearDown()
   {
-    m::close();
     (new FacebookStreamHttpClient()); // Resets the static dependency injection
   }
 


### PR DESCRIPTION
This is a more elegant way to configure Mockery.
It also avoid using `::close()` in `tearDown()` each time we need Mockery.
