### PR TITLE
Fix "Fatal error: Cannot use object of type stdClass as array" errors

### DIFF
--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -255,7 +255,7 @@ class FacebookRequest
     $headers = $connection->getResponseHeaders();
     $etagReceived = isset($headers['ETag']) ? $headers['ETag'] : null;
 
-    $decodedResult = json_decode($result);
+    $decodedResult = json_decode($result, true);
     if ($decodedResult === null) {
       $out = array();
       parse_str($result, $out);


### PR DESCRIPTION
When an embed object returned which has no own GraphObject subclass the resulting GraphObject instance recieves an stdClass for backingData which is wrong since the getProperty method expects it to be an array.

Example:

``` php
$me = (new FB\FacebookRequest(
    $session, 'GET', '/me?fields=email,picture'
))->execute()->getGraphObject(FB\GraphUser::className());

// prints "false" this is clearly wrong, i asked for an array.
var_dump(is_array($me->getProperty('picture')->asArray())); 

// "Fatal error: Cannot use object of type stdClass as array"
$me->getProperty('picture')->getProperty('url'); 
```

The reason behind this error is this is in the [`__construct` of `GraphObject`](https://github.com/complex857/facebook-php-sdk-v4/blob/a417ea0ae61fad14abab6b81728b79e8a912a082/src/Facebook/GraphNodes/GraphObject.php#L53).
The code tries to detect if it got an `\stdClass` and do converts it to an array if it's the top level data it received, but then goes to check for a `data` key and there is no conversion for that value.

The proposed change make everything received from the grap api in json, to be converted into arrays instead of `\stdClass` regardless of nesting so you I think you can delete the [explicit check and conversion](https://github.com/complex857/facebook-php-sdk-v4/blob/a417ea0ae61fad14abab6b81728b79e8a912a082/src/Facebook/GraphNodes/GraphObject.php#L47-L49) too in the `__construct` of `GraphObject`
