### PR TITLE
Fix "Fatal error: Cannot use object of type stdClass as array"

### DIFF
--- a/src/Facebook/GraphNodes/GraphObject.php
+++ b/src/Facebook/GraphNodes/GraphObject.php
@@ -50,7 +50,11 @@ class GraphObject
     $this->backingData = $raw;
 
     if (isset($this->backingData['data']) && count($this->backingData) === 1) {
-      $this->backingData = $this->backingData['data'];
+      if ($this->backingData['data'] instanceof \stdClass) {
+	    $this->backingData = get_object_vars($this->backingData['data']);
+      } else {
+	    $this->backingData = $this->backingData['data'];
+      }
     }
   }
 


### PR DESCRIPTION
Make sure that the "backingData" property's value will always be converted to an array.
This is a second attempt with a different approach, for the full explanation please see #177.
