### PR TITLE
Removed GET processing from CanvasLoginHelper.

### DIFF
--- a/src/Facebook/FacebookCanvasLoginHelper.php
+++ b/src/Facebook/FacebookCanvasLoginHelper.php
@@ -43,24 +43,12 @@ class FacebookCanvasLoginHelper extends FacebookSignedRequestFromInputHelper
   }
 
   /**
-   * Get raw signed request from either GET or POST.
+   * Get raw signed request from POST.
    *
    * @return string|null
    */
   public function getRawSignedRequest()
   {
-    /**
-     * v2.0 apps use GET for Canvas signed requests.
-     */
-    $rawSignedRequest = $this->getRawSignedRequestFromGet();
-    if ($rawSignedRequest) {
-      return $rawSignedRequest;
-    }
-
-    /**
-     * v1.0 apps use POST for Canvas signed requests, will eventually be
-     * deprecated.
-     */
     $rawSignedRequest = $this->getRawSignedRequestFromPost();
     if ($rawSignedRequest) {
       return $rawSignedRequest;

--- a/tests/FacebookCanvasLoginHelperTest.php
+++ b/tests/FacebookCanvasLoginHelperTest.php
@@ -13,15 +13,6 @@ class FacebookCanvasLoginHelperTest extends PHPUnit_Framework_TestCase
     $this->helper = new FacebookCanvasLoginHelper('123', 'foo_app_secret');
   }
 
-  public function testSignedRequestDataCanBeRetrievedFromGetData()
-  {
-    $_GET['signed_request'] = $this->rawSignedRequestAuthorized;
-
-    $rawSignedRequest = $this->helper->getRawSignedRequest();
-
-    $this->assertEquals($this->rawSignedRequestAuthorized, $rawSignedRequest);
-  }
-
   public function testSignedRequestDataCanBeRetrievedFromPostData()
   {
     $_POST['signed_request'] = $this->rawSignedRequestAuthorized;


### PR DESCRIPTION
Canvas does not send signed requests over GET.
