### PR TITLE
Corrected a typo

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use Facebook\FacebookSDKException;
+use Facebook\Exceptions\FacebookSDKException;
 
 if (!file_exists(__DIR__ . '/FacebookTestCredentials.php')) {
   throw new FacebookSDKException(


### PR DESCRIPTION
The correct FQCN is `Facebook\Exceptions\FacebookSDKException`.
