### PR TITLE
Added TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: php
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+before_script:
+  - composer self-update
+  - composer install --prefer-source --no-interaction --dev
+
+script:
+  - phpunit --coverage-text --exclude-group integration
+
+matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true


### PR DESCRIPTION
Since the integration tests can be skipped now we can automatically make sure all PR's have passing tests before they are considered. Yay! :)

@gfosco You just need to add the repo to [travis-ci](https://travis-ci.org). :)
