### PR TITLE
Fix for tests always failing when default timezone not set

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,7 +22,7 @@
  *
  */
 if ( ! ini_get('date.timezone')) {
-  date_default_timezone_set('America/Los_Angeles');
+  date_default_timezone_set('Europe/Paris');
 }
 
 require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Tests would always fail in some installations of PHP where the default timezone was not set.
