### PR TITLE
Moved the autoloader so that it is easier to strip the non-production stuff

### DIFF
--- a/src/Facebook/autoload.php
+++ b/src/Facebook/autoload.php
@@ -46,7 +46,7 @@ spl_autoload_register(function ($class)
   $prefix = 'Facebook\\';
 
   // base directory for the namespace prefix
-  $base_dir = defined('FACEBOOK_SDK_V4_SRC_DIR') ? FACEBOOK_SDK_V4_SRC_DIR : __DIR__ . '/src/Facebook/';
+  $base_dir = defined('FACEBOOK_SDK_V4_SRC_DIR') ? FACEBOOK_SDK_V4_SRC_DIR : __DIR__ . '/';
 
   // does the class use the namespace prefix?
   $len = strlen($prefix);


### PR DESCRIPTION
When non-composer people want to just pull in the `src/Facebook/*` files on production, this will keep them from having to manually move the autoloader and hard-coding the `FACEBOOK_SDK_V4_SRC_DIR` include path.
