### PR TITLE
Added support for Graph 2.1

### DIFF
--- a/src/Facebook/Entities/FacebookRequest.php
+++ b/src/Facebook/Entities/FacebookRequest.php
@@ -41,7 +41,7 @@ class FacebookRequest
   /**
    * @var string Default Graph API version for requests.
    */
-  protected static $defaultGraphApiVersion = 'v2.0';
+  protected static $defaultGraphApiVersion = 'v2.1';
 
   /**
    * @var FacebookApp The Facebook app entity.

--- a/src/Facebook/Helpers/FacebookPageTabHelper.php
+++ b/src/Facebook/Helpers/FacebookPageTabHelper.php
@@ -71,6 +71,9 @@ class FacebookPageTabHelper extends FacebookCanvasLoginHelper
   }
 
   /**
+   * @TODO Deprecated: Remove after November 5, 2014
+   * @see https://developers.facebook.com/blog/post/2014/08/07/Graph-API-v2.1/
+   *
    * Returns true if the page is liked by the user.
    *
    * @return boolean

--- a/tests/Entities/FacebookResponseTest.php
+++ b/tests/Entities/FacebookResponseTest.php
@@ -102,19 +102,6 @@ class FacebookResponseTest extends \PHPUnit_Framework_TestCase
       ], $decodedResponse);
   }
 
-  public function testASuccessfulBooleanResponseWillBeDecoded()
-  {
-    $app = new FacebookApp('123', 'foo_secret');
-    $graphResponse = 'true';
-    $response = new FacebookResponse($app, 200, [], $graphResponse);
-
-    $decodedResponse = $response->getDecodedBody();
-
-    $this->assertFalse($response->isError(), 'Did not expect Response to return an error.');
-    $this->assertEquals(['was_successful' => true], $decodedResponse);
-  }
-
-  /*
   public function testErrorStatusCanBeCheckedWhenAnErrorResponseIsReturned()
   {
     $app = new FacebookApp('123', 'foo_secret');
@@ -126,6 +113,5 @@ class FacebookResponseTest extends \PHPUnit_Framework_TestCase
     $this->assertTrue($response->isError(), 'Expected Response to return an error.');
     $this->assertInstanceOf('Facebook\Exceptions\FacebookResponseException', $exception);
   }
-  */
 
 }

--- a/tests/FacebookClientTest.php
+++ b/tests/FacebookClientTest.php
@@ -249,7 +249,7 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
       '/' . $testUserId);
     $graphObject = static::$testFacebookClient->sendRequest($request)->getGraphObject();
 
-    $this->assertTrue($graphObject->getProperty('was_successful'));
+    $this->assertTrue($graphObject->getProperty('success'));
   }
 
   public function initializeTestApp()

--- a/tests/Helpers/FacebookPageTabHelperTest.php
+++ b/tests/Helpers/FacebookPageTabHelperTest.php
@@ -38,7 +38,6 @@ class FacebookPageTabHelperTest extends \PHPUnit_Framework_TestCase
     $app = new FacebookApp('123', 'foo_app_secret');
     $helper = new FacebookPageTabHelper($app);
 
-    $this->assertTrue($helper->isLiked());
     $this->assertFalse($helper->isAdmin());
     $this->assertEquals('42', $helper->getPageId());
     $this->assertEquals('42', $helper->getPageData('id'));


### PR DESCRIPTION
Graph 2.0 still returns int and bools so no need to retrograde the `4.0-dev` branch (even though that functionality is pretty much broken). Graph 2.1 will still sometimes return key/value pairs on `/oauth/access_token` so I kept that functionality in there.
