### PR TITLE
Renamed FacebookRedirectLoginHelper method to be consistent with other helpers

### DIFF
--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -132,7 +132,7 @@ class FacebookRedirectLoginHelper
    *
    * @return AccessToken|null
    */
-  public function getAccessTokenFromRedirect(FacebookClient $client, $redirectUrl = null)
+  public function getAccessToken(FacebookClient $client, $redirectUrl = null)
   {
     if ($this->isValidRedirect()) {
       $code = $this->getCode();

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -105,7 +105,7 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
     $helper = new FacebookRedirectLoginHelper($app);
     $helper->disableSessionStatusCheck();
 
-    $accessToken = $helper->getAccessTokenFromRedirect($client, self::REDIRECT_URL);
+    $accessToken = $helper->getAccessToken($client, self::REDIRECT_URL);
 
     $this->assertInstanceOf('Facebook\Entities\AccessToken', $accessToken);
     $this->assertEquals('access_token_from_code', (string) $accessToken);


### PR DESCRIPTION
Renamed `getAccessTokenFromRedirect()` to just `getAccessToken()` to be consistent with the other helpers.
