### PR TITLE
Fix to allow FacebookRedirectLoginHelper->getAccessToken() to throw

### DIFF
--- a/src/Facebook/Entities/AccessToken.php
+++ b/src/Facebook/Entities/AccessToken.php
@@ -188,6 +188,8 @@ class AccessToken implements \Serializable
    * @param string|null $machineId
    *
    * @return AccessToken
+   *
+   * @throws FacebookSDKException
    */
   public static function getAccessTokenFromCode($code,
                                                 FacebookApp $app,
@@ -216,6 +218,8 @@ class AccessToken implements \Serializable
    * @param string|null $redirectUri
    *
    * @return AccessToken
+   *
+   * @throws FacebookSDKException
    */
   public static function getCodeFromAccessToken($accessToken,
                                                 FacebookApp $app,
@@ -239,6 +243,8 @@ class AccessToken implements \Serializable
    * @param FacebookClient $client The Facebook client.
    *
    * @return AccessToken
+   *
+   * @throws FacebookSDKException
    */
   public function extend(FacebookApp $app, FacebookClient $client)
   {

--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -131,6 +131,8 @@ class FacebookRedirectLoginHelper
    * @param string $redirectUrl The redirect URL.
    *
    * @return AccessToken|null
+   *
+   * @throws FacebookSDKException
    */
   public function getAccessToken(FacebookClient $client, $redirectUrl = null)
   {
@@ -139,11 +141,7 @@ class FacebookRedirectLoginHelper
       $redirectUrl = $redirectUrl ?: $this->getCurrentUri();
       $redirectUrl = $this->getFilteredUri($redirectUrl);
 
-      try {
-        return AccessToken::getAccessTokenFromCode($code, $this->app, $client, $redirectUrl);
-      } catch (FacebookSDKException $e) {
-        return null;
-      }
+      return AccessToken::getAccessTokenFromCode($code, $this->app, $client, $redirectUrl);
     }
     return null;
   }

--- a/src/Facebook/Helpers/FacebookSignedRequestFromInputHelper.php
+++ b/src/Facebook/Helpers/FacebookSignedRequestFromInputHelper.php
@@ -84,6 +84,8 @@ abstract class FacebookSignedRequestFromInputHelper
    * @param FacebookClient $client The Facebook client.
    *
    * @return AccessToken|null
+   *
+   * @throws \Facebook\Exceptions\FacebookSDKException
    */
   public function getAccessToken(FacebookClient $client)
   {


### PR DESCRIPTION
Don't know why the exception was being caught for `FacebookRedirectLoginHelper->getAccessToken()`, but in the case that the access token could not be obtained, the method would just return `null` with no way of finding out what went wrong. (In my case: `Couldn't resolve host 'graph.facebook.com'`). So this fixes that and allows the method to throw.
