### PR TITLE
Adding session_start() to the initialization docs.

### DIFF
--- a/docs/sdk_getting_started.fbmd
+++ b/docs/sdk_getting_started.fbmd
@@ -42,6 +42,7 @@ You will need to have configured a Facebook App, which you can obtain from the [
 Then, initialize the SDK with your app ID and secret:
 
 ~~~
+session_start(); // For the Facebook SDK to work correctly, you need to start a PHP session
 FacebookSession::setDefaultApplication('YOUR_APP_ID', 'YOUR_APP_SECRET');
 ~~~
 </card>


### PR DESCRIPTION
Saves lots of troubleshooting (mainly when people are testing the API alone, without any framework or complete setup behind). See http://stackoverflow.com/questions/23522583/facebooksdkexception-session-not-active-could-not-store-state
