### PR TITLE
At least one endpoint allows for the type parameter to be set in the URL...

### DIFF
--- a/src/Facebook/FacebookResponse.php
+++ b/src/Facebook/FacebookResponse.php
@@ -188,6 +188,9 @@ class FacebookResponse
       $url = parse_url($this->responseData->paging->$direction);
       parse_str($url['query'], $params);
 
+      if (isset($params['type']) && strpos($this->request->getPath(), $params['type']) != false){
+        unset($params['type']);
+      }
       return new FacebookRequest(
         $this->request->getSession(),
         $this->request->getMethod(),


### PR DESCRIPTION
... (paginated responses for example). If we're making a request to a URL with 'type' already specified, we don't need to include it as a query parameter
