### PR TITLE
[4.1] Added Facebook super service class

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ Usage
 Simple GET example of a user's profile.
 
 ```php
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
-use Facebook\FacebookClient;
-use Facebook\GraphNodes\GraphUser;
+use Facebook\Facebook;
 use Facebook\Exceptions\FacebookResponseException;
 use Facebook\Exceptions\FacebookSDKException;
 
-$facebookApp = new FacebookApp('{app-id}', '{app-secret}');
+$fb = new Facebook([
+  'app_id' => '{app-id}',
+  'app_secret' => '{app-secret}',
+  // 'default_access_token' => '{access-token}', // optional
+]);
 
 // Use one of the helper classes to get a Facebook\Entities\AccessToken entity.
 //   Facebook\Helpers\FacebookRedirectLoginHelper
@@ -31,13 +32,10 @@ $facebookApp = new FacebookApp('{app-id}', '{app-secret}');
 //   Facebook\Helpers\FacebookCanvasLoginHelper
 //   Facebook\Helpers\FacebookPageTabHelper
 
-// Get the Facebook\GraphNodes\GraphUser object for the current user:
-$facebookClient = new FacebookClient();
-$request = new FacebookRequest($facebookApp, '{access-token}', 'GET', '/me');
-
 try {
-  $facebookResponse = $facebookClient->sendRequest($request);
-  $me = $facebookResponse->getGraphObject(GraphUser::className());
+  // Get the Facebook\GraphNodes\GraphUser object for the current user:
+  $response = $fb->get('/me', '{access-token}');
+  $me = $response->getGraphUser();
   echo 'Logged in as ' . $me->getName();
 } catch(FacebookResponseException $e) {
   // When Graph returns an error

--- a/src/Facebook/Entities/FacebookRequest.php
+++ b/src/Facebook/Entities/FacebookRequest.php
@@ -23,6 +23,7 @@
  */
 namespace Facebook\Entities;
 
+use Facebook\Facebook;
 use Facebook\Exceptions\FacebookSDKException;
 
 /**
@@ -31,17 +32,6 @@ use Facebook\Exceptions\FacebookSDKException;
  */
 class FacebookRequest
 {
-
-  /**
-   * @TODO Move this to a global `Facebook` class.
-   * @const string Version number of the Facebook PHP SDK.
-   */
-  const VERSION = '4.1.0-dev';
-
-  /**
-   * @var string Default Graph API version for requests.
-   */
-  protected static $defaultGraphApiVersion = 'v2.1';
 
   /**
    * @var FacebookApp The Facebook app entity.
@@ -105,7 +95,7 @@ class FacebookRequest
     $this->setEndpoint($endpoint);
     $this->setParams($params);
     $this->setETag($eTag);
-    $this->graphVersion = $graphVersion ?: static::getDefaultGraphApiVersion();
+    $this->graphVersion = $graphVersion ?: Facebook::DEFAULT_GRAPH_VERSION;
   }
 
   /**
@@ -387,29 +377,6 @@ class FacebookRequest
   }
 
   /**
-   * Returns the default Graph version.
-   *
-   * @param string|null $graphApiVersion The Graph version we want to use.
-   *
-   * @return string
-   */
-  public static function getDefaultGraphApiVersion($graphApiVersion = null)
-  {
-    return $graphApiVersion ?: static::$defaultGraphApiVersion;
-  }
-
-  /**
-   * Sets the default Graph API version.
-   *
-   * @param string $graphApiVersion
-   */
-  public static function setDefaultGraphApiVersion($graphApiVersion)
-  {
-    static::$defaultGraphApiVersion = $graphApiVersion;
-  }
-
-
-  /**
    * Return the default headers that every request should use.
    *
    * @return array
@@ -417,7 +384,7 @@ class FacebookRequest
   public static function getDefaultHeaders()
   {
     return [
-      'User-Agent' => 'fb-php-' . static::VERSION,
+      'User-Agent' => 'fb-php-' . Facebook::VERSION,
       'Accept-Encoding' => '*',
     ];
   }

--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook;
+
+use Facebook\Entities\FacebookApp;
+use Facebook\Entities\AccessToken;
+use Facebook\Entities\FacebookRequest;
+use Facebook\Entities\FacebookBatchRequest;
+use Facebook\Entities\FacebookResponse;
+use Facebook\Entities\FacebookBatchResponse;
+use Facebook\HttpClients\FacebookHttpClientInterface;
+use Facebook\HttpClients\FacebookCurlHttpClient;
+use Facebook\HttpClients\FacebookStreamHttpClient;
+use Facebook\HttpClients\FacebookGuzzleHttpClient;
+use Facebook\Exceptions\FacebookSDKException;
+
+/**
+ * Class Facebook
+ * @package Facebook
+ *
+ * @TODO Add helpers to superclass
+ */
+class Facebook
+{
+
+  /**
+   * @const string Version number of the Facebook PHP SDK.
+   */
+  const VERSION = '4.1.0-dev';
+
+  /**
+   * @const string Default Graph API version for requests.
+   */
+  const DEFAULT_GRAPH_VERSION = 'v2.1';
+
+  /**
+   * @const string The name of the environment variable
+   *               that contains the app ID.
+   */
+  const APP_ID_ENV_NAME = 'FACEBOOK_APP_ID';
+
+  /**
+   * @const string The name of the environment variable
+   *               that contains the app secret.
+   */
+  const APP_SECRET_ENV_NAME = 'FACEBOOK_APP_SECRET';
+
+  /**
+   * @var FacebookApp The FacebookApp entity.
+   */
+  protected $app;
+
+  /**
+   * @var FacebookClient The Facebook client service.
+   */
+  protected $client;
+
+  /**
+   * @var AccessToken|null The default access token to use with requests.
+   */
+  protected $defaultAccessToken;
+
+  /**
+   * @var string|null The default Graph version we want to use.
+   */
+  protected $defaultGraphVersion;
+
+  /**
+   * @TODO Add FacebookInputInterface
+   * @TODO Add FacebookSessionInterface
+   * @TODO Add FacebookUrlInterface
+   * @TODO Add FacebookRandomGeneratorInterface
+   * @TODO Add FacebookRequestInterface
+   * @TODO Add FacebookResponseInterface
+   */
+
+  /**
+   * Instantiates a new Facebook super-class object.
+   *
+   * @param array $config
+   *
+   * @throws FacebookSDKException
+   */
+  public function __construct(array $config = [])
+  {
+    $appId = isset($config['app_id'])
+      ? $config['app_id']
+      : getenv(static::APP_ID_ENV_NAME);
+    if ( ! $appId) {
+      throw new FacebookSDKException(
+        'Required "app_id" key not supplied in config and'
+        . ' could not find fallback environment variable "' . static::APP_ID_ENV_NAME . '"'
+      );
+    }
+
+    $appSecret = isset($config['app_secret'])
+      ? $config['app_secret']
+      : getenv(static::APP_SECRET_ENV_NAME);
+    if ( ! $appSecret) {
+      throw new FacebookSDKException(
+        'Required "app_secret" key not supplied in config and'
+        . ' could not find fallback environment variable "' . static::APP_SECRET_ENV_NAME . '"'
+      );
+    }
+
+    $this->app = new FacebookApp($appId, $appSecret);
+
+    $httpClientHandler = null;
+    if (isset($config['http_client_handler'])) {
+      if ( $config['http_client_handler'] instanceof FacebookHttpClientInterface) {
+        $httpClientHandler = $config['http_client_handler'];
+      } elseif ($config['http_client_handler'] === 'curl') {
+        $httpClientHandler = new FacebookCurlHttpClient();
+      } elseif ($config['http_client_handler'] === 'stream') {
+        $httpClientHandler = new FacebookStreamHttpClient();
+      } elseif ($config['http_client_handler'] === 'guzzle') {
+        $httpClientHandler = new FacebookGuzzleHttpClient();
+      } else {
+        throw new \InvalidArgumentException(
+          'The http_client_handler must be set to "curl", "stream", "guzzle", '
+          . ' or be an instance of Facebook\HttpClients\FacebookHttpClientInterface'
+        );
+      }
+    }
+    $enableBeta = isset($config['enable_beta_mode']) && $config['enable_beta_mode'] === true;
+    $this->client = new FacebookClient($httpClientHandler, $enableBeta);
+
+    if (isset($config['default_access_token'])) {
+      if (is_string($config['default_access_token'])) {
+        $this->defaultAccessToken = new AccessToken($config['default_access_token']);
+      } elseif ( ! $config['default_access_token'] instanceof AccessToken) {
+        throw new \InvalidArgumentException(
+          'The "default_access_token" provided must be of type "string"'
+          . ' or Facebook\Entities\AccessToken'
+        );
+      }
+    }
+
+    $this->defaultGraphVersion = isset($config['default_graph_version'])
+      ? $config['default_graph_version']
+      : static::DEFAULT_GRAPH_VERSION;
+  }
+
+  /**
+   * Returns the FacebookApp entity.
+   *
+   * @return FacebookApp
+   */
+  public function getApp()
+  {
+    return $this->app;
+  }
+
+  /**
+   * Returns the FacebookClient service.
+   *
+   * @return FacebookClient
+   */
+  public function getClient()
+  {
+    return $this->client;
+  }
+
+  /**
+   * Returns the default AccessToken entity.
+   *
+   * @return AccessToken|null
+   */
+  public function getDefaultAccessToken()
+  {
+    return $this->defaultAccessToken;
+  }
+
+  /**
+   * Returns the default Graph version.
+   *
+   * @return string
+   */
+  public function getDefaultGraphVersion()
+  {
+    return $this->defaultGraphVersion;
+  }
+
+  /**
+   * Sends a GET request to Graph and returns the result.
+   *
+   * @param string $endpoint
+   * @param AccessToken|string|null $accessToken
+   * @param string|null $eTag
+   * @param string|null $graphVersion
+   *
+   * @return FacebookResponse
+   *
+   * @throws FacebookSDKException
+   */
+  public function get(
+    $endpoint,
+    $accessToken = null,
+    $eTag = null,
+    $graphVersion = null)
+  {
+    return $this->sendRequest(
+      'GET',
+      $endpoint,
+      $params = [],
+      $accessToken,
+      $eTag,
+      $graphVersion);
+  }
+
+  /**
+   * Sends a POST request to Graph and returns the result.
+   *
+   * @param string $endpoint
+   * @param array $params
+   * @param AccessToken|string|null $accessToken
+   * @param string|null $eTag
+   * @param string|null $graphVersion
+   *
+   * @return FacebookResponse
+   *
+   * @throws FacebookSDKException
+   */
+  public function post(
+    $endpoint,
+    array $params = [],
+    $accessToken = null,
+    $eTag = null,
+    $graphVersion = null)
+  {
+    return $this->sendRequest(
+      'POST',
+      $endpoint,
+      $params,
+      $accessToken,
+      $eTag,
+      $graphVersion);
+  }
+
+  /**
+   * Sends a DELETE request to Graph and returns the result.
+   *
+   * @param string $endpoint
+   * @param AccessToken|string|null $accessToken
+   * @param string|null $eTag
+   * @param string|null $graphVersion
+   *
+   * @return FacebookResponse
+   *
+   * @throws FacebookSDKException
+   */
+  public function delete(
+    $endpoint,
+    $accessToken = null,
+    $eTag = null,
+    $graphVersion = null)
+  {
+    return $this->sendRequest(
+      'DELETE',
+      $endpoint,
+      $params = [],
+      $accessToken,
+      $eTag,
+      $graphVersion);
+  }
+
+  /**
+   * Sends a request to Graph and returns the result.
+   *
+   * @param string $method
+   * @param string $endpoint
+   * @param array $params
+   * @param AccessToken|string|null $accessToken
+   * @param string|null $eTag
+   * @param string|null $graphVersion
+   *
+   * @return FacebookResponse
+   *
+   * @throws FacebookSDKException
+   */
+  public function sendRequest(
+    $method,
+    $endpoint,
+    array $params = [],
+    $accessToken = null,
+    $eTag = null,
+    $graphVersion = null)
+  {
+    $accessToken = $accessToken ?: $this->defaultAccessToken;
+    $graphVersion = $graphVersion ?: $this->defaultGraphVersion;
+    $request = $this->request($method, $endpoint, $params, $accessToken, $eTag, $graphVersion);
+    return $this->client->sendRequest($request);
+  }
+
+  /**
+   * Sends a batched request to Graph and returns the result.
+   *
+   * @param array $requests
+   * @param AccessToken|string|null $accessToken
+   * @param string|null $graphVersion
+   *
+   * @return FacebookBatchResponse
+   *
+   * @throws FacebookSDKException
+   */
+  public function sendBatchRequest(
+    array $requests,
+    $accessToken = null,
+    $graphVersion = null)
+  {
+    $accessToken = $accessToken ?: $this->defaultAccessToken;
+    $graphVersion = $graphVersion ?: $this->defaultGraphVersion;
+    $batchRequest = new FacebookBatchRequest(
+      $this->app,
+      $accessToken,
+      $requests,
+      $graphVersion
+    );
+
+    return $this->client->sendBatchRequest($batchRequest);
+  }
+
+  /**
+   * Instantiates a new FacebookRequest entity.
+   *
+   * @param string $method
+   * @param string $endpoint
+   * @param array $params
+   * @param AccessToken|string|null $accessToken
+   * @param string|null $eTag
+   * @param string|null $graphVersion
+   *
+   * @return FacebookRequest
+   *
+   * @throws FacebookSDKException
+   */
+  public function request(
+    $method,
+    $endpoint,
+    array $params = [],
+    $accessToken = null,
+    $eTag = null,
+    $graphVersion = null)
+  {
+    $accessToken = $accessToken ?: $this->defaultAccessToken;
+    $graphVersion = $graphVersion ?: $this->defaultGraphVersion;
+    return new FacebookRequest(
+      $this->app,
+      $accessToken,
+      $method,
+      $endpoint,
+      $params,
+      $eTag,
+      $graphVersion
+    );
+  }
+
+}

--- a/src/Facebook/GraphNodes/GraphObject.php
+++ b/src/Facebook/GraphNodes/GraphObject.php
@@ -65,7 +65,9 @@ class GraphObject extends Collection
     foreach ($data as $k => $v) {
       if (
         $this->shouldCastAsDateTime($k)
-        && (is_numeric($v) || $this->isIso8601DateString($v))
+        && (is_numeric($v)
+          || $k === 'birthday'
+          || $this->isIso8601DateString($v))
       ) {
         $items[$k] = $this->castToDateTime($v);
       } else {

--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -23,9 +23,9 @@
  */
 namespace Facebook\Helpers;
 
+use Facebook\Facebook;
 use Facebook\Entities\AccessToken;
 use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
 use Facebook\Exceptions\FacebookSDKException;
 use Facebook\FacebookClient;
 
@@ -86,14 +86,14 @@ class FacebookRedirectLoginHelper
                               $version = null,
                               $separator = '&')
   {
-    $version = FacebookRequest::getDefaultGraphApiVersion($version);
+    $version = $version ?: Facebook::DEFAULT_GRAPH_VERSION;
     $state = $this->generateState();
     $this->storeState($state);
     $params = [
       'client_id' => $this->app->getId(),
       'redirect_uri' => $redirectUrl,
       'state' => $state,
-      'sdk' => 'php-sdk-' . FacebookRequest::VERSION,
+      'sdk' => 'php-sdk-' . Facebook::VERSION,
       'scope' => implode(',', $scope)
     ];
 

--- a/tests/Entities/FacebookBatchRequestTest.php
+++ b/tests/Entities/FacebookBatchRequestTest.php
@@ -23,6 +23,7 @@
  */
 namespace Facebook\Tests\Entities;
 
+use Facebook\Facebook;
 use Facebook\Entities\FacebookApp;
 use Facebook\Entities\FacebookRequest;
 use Facebook\Entities\FacebookBatchRequest;
@@ -212,7 +213,7 @@ class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
   public function requestsAndExpectedResponsesProvider()
   {
     $headers = $this->defaultHeaders();
-    $apiVersion = FacebookRequest::getDefaultGraphApiVersion();
+    $apiVersion = Facebook::DEFAULT_GRAPH_VERSION;
     return [
       [
         new FacebookRequest(null, null, 'GET', '/foo', ['foo' => 'bar']),
@@ -255,7 +256,7 @@ class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
     $params = $batchRequest->getParams();
 
     $expectedHeaders = json_encode($this->defaultHeaders());
-    $version = FacebookRequest::getDefaultGraphApiVersion();
+    $version = Facebook::DEFAULT_GRAPH_VERSION;
     $expectedBatchParams = [
       'batch' => '[{"headers":'.$expectedHeaders.',"method":"GET","relative_url":"\\/' . $version . '\\/foo?access_token=bar_token&appsecret_proof=2ceec40b7b9fd7d38fff1767b766bcc6b1f9feb378febac4612c156e6a8354bd","name":"foo_name"},'
         .'{"headers":'.$expectedHeaders.',"method":"POST","relative_url":"\\/' . $version . '\\/bar","body":"foo=bar&access_token=foo_token&appsecret_proof=df4256903ba4e23636cc142117aa632133d75c642bd2a68955be1443bd14deb9"}]',

--- a/tests/Entities/FacebookRequestTest.php
+++ b/tests/Entities/FacebookRequestTest.php
@@ -23,6 +23,7 @@
  */
 namespace Facebook\Tests\Entities;
 
+use Facebook\Facebook;
 use Facebook\Entities\FacebookApp;
 use Facebook\Entities\FacebookRequest;
 
@@ -104,14 +105,14 @@ class FacebookRequestTest extends \PHPUnit_Framework_TestCase
 
     $getUrl = $getRequest->getUrl();
     $expectedParams = 'foo=bar&access_token=foo_token&appsecret_proof=df4256903ba4e23636cc142117aa632133d75c642bd2a68955be1443bd14deb9';
-    $expectedUrl = '/' . FacebookRequest::getDefaultGraphApiVersion() . '/foo?' . $expectedParams;
+    $expectedUrl = '/' . Facebook::DEFAULT_GRAPH_VERSION . '/foo?' . $expectedParams;
 
     $this->assertEquals($expectedUrl, $getUrl);
 
     $postRequest = new FacebookRequest($app, 'foo_token', 'POST', '/bar', ['foo' => 'bar']);
 
     $postUrl = $postRequest->getUrl();
-    $expectedUrl = '/' . FacebookRequest::getDefaultGraphApiVersion() . '/bar';
+    $expectedUrl = '/' . Facebook::DEFAULT_GRAPH_VERSION . '/bar';
 
     $this->assertEquals($expectedUrl, $postUrl);
   }
@@ -134,7 +135,7 @@ class FacebookRequestTest extends \PHPUnit_Framework_TestCase
     $url = $request->getUrl();
 
     $expectedParams = 'access_token=bar_access_token&appsecret_proof=bar_app_secret';
-    $expectedUrl = '/' . FacebookRequest::getDefaultGraphApiVersion() . '/foo?' . $expectedParams;
+    $expectedUrl = '/' . Facebook::DEFAULT_GRAPH_VERSION . '/foo?' . $expectedParams;
     $this->assertEquals($expectedUrl, $url);
 
     $params = $request->getParams();

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests;
+
+use Mockery as m;
+use Facebook\Facebook;
+use Facebook\FacebookClient;
+use Facebook\HttpClients\FacebookHttpClientInterface;
+
+class FooClientInterface implements FacebookHttpClientInterface
+{
+  public function getResponseHeaders() { return ['X-foo-header' => 'bar']; }
+  public function getResponseHttpStatusCode() { return 1337; }
+  public function send($url, $method = 'GET', array $parameters = [], array $headers = []) { return 'foo_response'; }
+}
+
+class FacebookTest extends \PHPUnit_Framework_TestCase
+{
+
+  protected $config = [
+    'app_id' => '1337',
+    'app_secret' => 'foo_secret',
+  ];
+
+  /**
+   * @expectedException \Facebook\Exceptions\FacebookSDKException
+   */
+  public function testInstantiatingWithoutAppIdThrows()
+  {
+    $config = [
+      'app_secret' => 'foo_secret',
+    ];
+    $fb = new Facebook($config);
+  }
+
+  /**
+   * @expectedException \Facebook\Exceptions\FacebookSDKException
+   */
+  public function testInstantiatingWithoutAppSecretThrows()
+  {
+    $config = [
+      'app_id' => 'foo_id',
+    ];
+    $fb = new Facebook($config);
+  }
+
+  /**
+   * @expectedException \InvalidArgumentException
+   */
+  public function testSettingAnInvalidHttpClientHandlerThrows()
+  {
+    $config = array_merge($this->config, [
+      'http_client_handler' => 'foo_handler',
+    ]);
+    $fb = new Facebook($config);
+  }
+
+  public function testCurlHttpClientHandlerCanBeForced()
+  {
+    $config = array_merge($this->config, [
+      'http_client_handler' => 'curl'
+    ]);
+    $fb = new Facebook($config);
+    $this->assertInstanceOf('Facebook\HttpClients\FacebookCurlHttpClient',
+      $fb->getClient()->getHttpClientHandler());
+  }
+
+  public function testStreamHttpClientHandlerCanBeForced()
+  {
+    $config = array_merge($this->config, [
+      'http_client_handler' => 'stream'
+    ]);
+    $fb = new Facebook($config);
+    $this->assertInstanceOf('Facebook\HttpClients\FacebookStreamHttpClient',
+      $fb->getClient()->getHttpClientHandler());
+  }
+
+  public function testGuzzleHttpClientHandlerCanBeForced()
+  {
+    $config = array_merge($this->config, [
+      'http_client_handler' => 'guzzle'
+    ]);
+    $fb = new Facebook($config);
+    $this->assertInstanceOf('Facebook\HttpClients\FacebookGuzzleHttpClient',
+      $fb->getClient()->getHttpClientHandler());
+  }
+
+  /**
+   * @expectedException \InvalidArgumentException
+   */
+  public function testSettingAnAccessThatIsNotStringOrAccessTokenThrows()
+  {
+    $config = array_merge($this->config, [
+        'default_access_token' => 123,
+      ]);
+    $fb = new Facebook($config);
+  }
+
+  public function testCreatingANewRequestWillDefaultToTheProperConfig()
+  {
+    $config = array_merge($this->config, [
+        'default_access_token' => 'foo_token',
+        'http_client_handler' => new FooClientInterface(),
+        'enable_beta_mode' => true,
+        'default_graph_version' => 'v1337',
+      ]);
+    $fb = new Facebook($config);
+
+    $request = $fb->request('FOO_VERB', '/foo');
+    $this->assertInstanceOf('Facebook\Tests\FooClientInterface',
+      $fb->getClient()->getHttpClientHandler());
+    $this->assertEquals(FacebookClient::BASE_GRAPH_URL_BETA,
+      $fb->getClient()->getBaseGraphUrl());
+    $this->assertEquals('1337', $request->getApp()->getId());
+    $this->assertEquals('foo_secret', $request->getApp()->getSecret());
+    $this->assertEquals('foo_token', (string) $request->getAccessToken());
+    $this->assertEquals('v1337', $request->getGraphVersion());
+  }
+
+}

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -24,8 +24,8 @@
 namespace Facebook\Tests\Helpers;
 
 use Mockery as m;
+use Facebook\Facebook;
 use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
 use Facebook\Helpers\FacebookRedirectLoginHelper;
 
 class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
@@ -49,7 +49,7 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
       'client_id' => '123',
       'redirect_uri' => self::REDIRECT_URL,
       'state' => $_SESSION['FBRLH_state'],
-      'sdk' => 'php-sdk-' . FacebookRequest::VERSION,
+      'sdk' => 'php-sdk-' . Facebook::VERSION,
       'scope' => implode(',', $scope),
     ];
     foreach ($params as $key => $value) {


### PR DESCRIPTION
Hey guys! How have you been? :)

So since momentum on 4.1 slowed down a bit I thought I'd post a first draft of the `Facebook\Facebook` super service class. This ties all the major elements of the SDK together to make it as crazy-simple to use as possible.

``` php
use Facebook\Facebook;

$fb = new Facebook([
    'app_id' => $config['app_id'],
    'app_secret' => $config['app_secret'],
    'default_access_token' => $config['access_token'], // optional
]);

// Get a user
$graphUser = $fb->get('/me')->getGraphUser();

// Post to user timeline
$response = $fb->post('/me/feed', ['message' => 'Foo message']);

// Delete a node
$response = $fb->delete('/{node-id}');
```

If you don't provide a `default_access_token`, you'll need to pass it in the method that makes the requests.

``` php
$res = $fb->get('/me', '{access-token}');
$res = $fb->post('/me/feed', ['foo' => 'bar'], '{access-token}');
$res = $fb->delete('/{node-id}', '{access-token}');
```

Here's a full list of config options you can pass to the `Facebook\Facebook` super service class in this first draft:

``` php
$fb = new Facebook([
    // The Facebook app ID
    'app_id' => '{app-id}',
    // The Facebook app secret
    'app_secret' => '{app-secret}',
    // The default fall-back access token if one is not provided
    'default_access_token' => '{access-token}',
    // A custom HTTP client handler that must implement
    // Facebook\HttpClients\FacebookHttpClientInterface
    'http_client_handler' => new MyCustomHttpClient(),
    // Force use of the cURL HTTP client
    'use_curl_http_client' => true,
    // Force use of the stream wrapper HTTP client
    'use_stream_http_client' => true,
    // Force use of the Guzzle HTTP client (requires Guzzle)
    'use_guzzle_http_client' => true,
    // Enable the graph.beta.facebook.com endpoint
    'enable_beta_mode' => true,
    // Change the default Graph version
    'default_graph_version' => 'v1.0',
]);
```

Finally this implementation will fallback to the `FACEBOOK_APP_ID` & `FACEBOOK_APP_SECRET` environment variables so you can new up with no config at all.

``` php
$fb = new Facebook\Facebook();
```

This is really handy when your server config is set in the environment variables for better security & easier deployment. :)

I'd like to add helper factories, etc to this but it's not 100% necessary for 4.1 launch.

Hope you guys like it!
