### PR TITLE
[4.1] Fixed birthday not being converted to DateTime

### DIFF
--- a/src/Facebook/GraphNodes/GraphObject.php
+++ b/src/Facebook/GraphNodes/GraphObject.php
@@ -65,7 +65,9 @@ class GraphObject extends Collection
     foreach ($data as $k => $v) {
       if (
         $this->shouldCastAsDateTime($k)
-        && (is_numeric($v) || $this->isIso8601DateString($v))
+        && (is_numeric($v)
+          || $k === 'birthday'
+          || $this->isIso8601DateString($v))
       ) {
         $items[$k] = $this->castToDateTime($v);
       } else {


### PR DESCRIPTION
Since Graph returns the birthday as a non-ISO 8601 formatted string, we have to accommodate for the edge case.

This fixes #241.
