### PR TITLE
Fixed testing timezone bug.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,9 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-if ( ! ini_get('date.timezone')) {
-  date_default_timezone_set('Europe/Paris');
-}
+date_default_timezone_set('Europe/Paris');
 
 require_once __DIR__ . '/../vendor/autoload.php';
 


### PR DESCRIPTION
My default timezone was set to UTC which caused a test to fail.
