### PR TITLE
Updated version constraint

### DIFF
--- a/docs/sdk_getting_started.fbmd
+++ b/docs/sdk_getting_started.fbmd
@@ -17,7 +17,7 @@ If you're using [Composer](https://getcomposer.org/) as a package manager for PH
 ~~~~
 {
   "require" : {
-    "facebook/php-sdk-v4" : "4.0.*"
+    "facebook/php-sdk-v4" : "~4.0.12"
   }
 }
 ~~~~


### PR DESCRIPTION
I recently [uncovered a bug](https://github.com/SammyK/LaravelFacebookSdk/issues/12#issuecomment-62321565) that would install the wrong version of the PHP SDK.

Since the Facebook PHP SDK does not follow semantic versioning, trying to install `~4.0` means composer would pull in everything `>=4.0,<5.0`.

https://getcomposer.org/doc/01-basic-usage.md#package-versions

But 4.1 of the SDK is marked as dev so it shouldn't be pulling it in unless your `minimum-stability` is set to `dev` in your `composer.json`.

https://getcomposer.org/doc/04-schema.md#minimum-stability

So this means people using `~4.0` are trying to pull in `v4.0` and instead get `dev-master`. Doh!

Although the docs don't use the `~` constraint: https://developers.facebook.com/docs/php/gettingstarted/4.0.0

It says to use  `"facebook/php-sdk-v4" : "4.0.*"` which means any version of `4.0.x` - so `4.0.1` would satisfy this constraint. It would be better to use `~4.0.12` so that you're always getting the latest stable version of the SDK. :)
