### PR TITLE
[4.1] Added baller pagination

### DIFF
--- a/docs/Facebook.fbmd
+++ b/docs/Facebook.fbmd
@@ -151,6 +151,14 @@ Returns the instance of `Facebook\FacebookClient` for the instantiated service.
 </card>
 
 <card>
+### getLastResponse() {#get-last-response}
+~~~~
+public Facebook\Entities\FacebookResponse|Facebook\Entities\FacebookBatchResponse|null getLastResponse()
+~~~~
+Returns the last response received from the Graph API in the form of a `Facebook\Entities\FacebookResponse` or `Facebook\Entities\FacebookBatchResponse`.
+</card>
+
+<card>
 ### getDefaultAccessToken() {#get-default-access-token}
 ~~~~
 public AccessToken|null getDefaultAccessToken()
@@ -305,4 +313,49 @@ Returns a [`Facebook\Helpers\FacebookRedirectLoginHelper`](/docs/php/FacebookRed
 ~~~~
 $helper = $fb->getRedirectLoginHelper();
 ~~~~
+</card>
+
+<card>
+### next() {#next}
+~~~~
+public Facebook\GraphNodes\GraphList|null next(Facebook\GraphNodes\GraphList $graphList)
+~~~~
+
+Requests and returns the next page of results in a [`Facebook\GraphNodes\GraphList`](/docs/php/GraphList) object. If the next page returns no results, `null` will be returned.
+
+~~~~
+// Iterate over 5 pages max
+$maxPages = 5;
+
+// Get a list of photo objects
+$response = $fb->get('/me/photos?fields=id,source,likes&limit=5');
+
+$photosList = $response->getGraphList();
+
+if (count($photosList) > 0) {
+  $pageCount = 0;
+  do {
+    foreach ($photosList as $photo) {
+      var_dump($photo->asArray());
+
+      // Deep pagination is supported on child GraphList's
+      $likes = $photo['likes'];
+      do {
+        echo '<p>Likes:</p>' . "\n\n";
+        var_dump($likes->asArray());
+      } while ($likes = $fqb->next($likes));
+    }
+    $pageCount++;
+  } while ($pageCount < $maxPages && $photosList = $fb->next($photosList));
+}
+~~~~
+</card>
+
+<card>
+### previous() {#previous}
+~~~~
+public Facebook\GraphNodes\GraphList|null previous(Facebook\GraphNodes\GraphList $graphList)
+~~~~
+
+Requests and returns the previous page of results in a `Facebook\GraphNodes\GraphList` object. Functions just like `next()` above, but in the opposite direction of pagination.
 </card>

--- a/docs/GraphList.fbmd
+++ b/docs/GraphList.fbmd
@@ -1,0 +1,71 @@
+<card>
+# GraphList for the Facebook SDK for PHP
+
+When a list of nodes is returned from a Graph request, it can be cast as a `GraphList` which provides convenient ways of interacting with the data which includes pagination.
+</card>
+
+<card>
+## Facebook\GraphNodes\GraphList {#overview}
+
+You can grab a `GraphList` from a response from Graph.
+
+~~~~
+$graphList = $request->getGraphList();
+~~~~
+
+Usage:
+
+~~~~
+// Iterate over all the GraphObject in the list
+foreach ($graphList as $graphObject) {
+  // . . .
+}
+~~~~
+</card>
+
+<card>
+## Pagination {#pagination}
+
+With the help of the `Facebook\Facebook` super service class, the `GraphList` collection can grab the next and previous sets of data.
+
+~~~~
+$listOfAlbums = $response->getGraphList();
+
+// Get the next page of results
+$nextPageOfAlbums = $fb->next($listOfAlbums);
+// Or the previous page of results
+$previousPageOfAlbums = $fb->previous($previousOfAlbums);
+~~~~
+
+When the next or previous page returns no results, `$fb->next()` will return `null`.
+</card>
+
+<card>
+## Deep Pagination {#deep-pagination}
+
+Sometimes Graph will return a list of nodes within a node. Paginating on these sub lists can be non-trivial. Fortunately, the `GraphList` collection takes the guesswork out and allows you to paginate deeply within a `GraphList`.
+
+The following example paginates over the first 5 pages of a list of Facebook pages. For each page it paginates over all the likes for that page.
+
+~~~~
+$listOfPages = $response->getGraphList();
+// Only grab 5 pages
+$maxPages = 5;
+$pageCount = 0;
+
+do {
+  echo '<h1>Page #' . $page_count . ':</h1>' . "\n\n";
+
+  foreach ($listOfPages as $page) {
+    var_dump($page->asArray());
+
+    $likes = $page['likes'];
+    do {
+      echo '<p>Likes:</p>' . "\n\n";
+      var_dump($likes->asArray());
+    } while ($likes = $fb->next($likes));
+  }
+  $pageCount++;
+} while ($pageCount < $maxPages && $listOfPages = $fb->next($listOfPages));
+~~~~
+</card>

--- a/docs/GraphObject.fbmd
+++ b/docs/GraphObject.fbmd
@@ -1,17 +1,19 @@
 <card>
 # GraphObject for the Facebook SDK for PHP
 
-Represents an object returned by the Graph API.
+A `GraphObject` is a collection that represents a node returned by the Graph API.
 
 </card>
 
 <card>
 ## Facebook\GraphObject {#overview}
 
-This base class has several subclasses, some are provided by default:
+This base class has several subclasses:
 
-[__GraphUser__](#user-instance-methods)  
-[__GraphLocation__](#location-instance-methods)  
+[__GraphUser__](#user-instance-methods)
+[__GraphPage__](#page-instance-methods)
+[__GraphAlbum__](#album-instance-methods)
+[__GraphLocation__](#location-instance-methods)
 [__GraphSessionInfo__](#sessioninfo-instance-methods)  
 
 Usage:
@@ -21,14 +23,10 @@ Usage:
 $object = $response->getGraphObject();
 
 // Get the response typed as a GraphUser
-$user = $response->getGraphObject(GraphUser::className());
-// or convert the base object previously accessed
-// $user = $object->cast(GraphUser::className());
+$user = $response->getGraphUser());
 
-// Get the response typed as a GraphLocation
-$loc = $response->getGraphObject(GraphLocation::className());
-// or convert the base object previously accessed
-// $loc = $object->cast(GraphLocation::className());
+// Get the response typed as a GraphPage
+$page = $response->getGraphPage();
 
 // User example
 echo $object->getProperty('name');
@@ -40,7 +38,31 @@ echo $loc->getCountry();
 
 // SessionInfo example
 $info = $session->getSessionInfo());
-echo $info->getxpiresAt();
+echo $info->getExpiresAt();
+~~~~
+
+</card>
+
+<card>
+## SPL Libraries {#spl}
+
+The `GraphObject` collection and its subclasses implement several [SPL](http://php.net/manual/en/book.spl.php) libraries and [predefined PHP interfaces and classes](http://php.net/manual/en/reserved.interfaces.php) which make it convenient to work with the object in PHP. The supported libraries are `ArrayAccess`, `ArrayIterator`, `Countable`, and `IteratorAggregate`.
+
+All of the following operations are possible on a `GraphObject`.
+
+~~~~
+$graphObject = $response->getGraphObject();
+
+// Array access
+$id = $graphObject['id'];
+
+// Iteration
+foreach ($graphObject as $key => $value) {
+  // . . .
+}
+
+// Counting
+$total = count($graphObject);
 ~~~~
 
 </card>
@@ -48,25 +70,32 @@ echo $info->getxpiresAt();
 <card>
 ## GraphObject Instance Methods {#instance-methods}
 
-### cast {#cast}
-`cast(string $type)`  
-Returns a new instance of a GraphObject subclass with this objects underlying data.
 
-### asArray {#asarray}
+### asArray {#as-array}
 `asArray()`  
 Returns the raw representation (associative arrays, nested) of this objects underlying data.
 
-### getProperty {#getproperty}
-`getProperty(string $name, string $type = 'Facebook\GraphObject')`  
-Gets the value of a named key for this graph object.  If the value is a scalar (string, number, etc.) it will be returned.  If it's an associative array, it will be returned as a GraphObject cast to the appropriate subclass type if provided.
 
-### getPropertyAsArray {#getproparray}
-`getPropertyAsArray()`  
-Gets the contents of a named array property on this graph object.  If the values are scalar (strings, numbers, etc.) they will be returned as-is.  If the values are associative arrays, they will be returned as GraphObjects cast to the appropriate subclass type if provided.
+### asJson {#as-json}
+`asJson()`
+Returns the data as a JSON string.
 
-### getPropertyNames
+
+### getProperty {#get-property}
+`getProperty(string $name, string $default = 'foo')`
+Gets the value of a named key for this graph object.  If the value is a scalar (string, number, etc.) it will be returned.  If it's an associative array, it will be returned as a GraphObject.
+
+The second argument lets you define a default value to return if the property doesn't exist.
+
+
+### getPropertyNames {#get-property-names}
 `getPropertyNames()`  
 Returns an array with the names of all properties present on this graph object.
+
+
+### map {#map}
+`map(Closure $callback)`
+Provides a way to map over the data within the collection just like `array_map()`.
 </card>
 
 <card>

--- a/docs/sdk_reference.fbmd
+++ b/docs/sdk_reference.fbmd
@@ -117,16 +117,20 @@ FB(devsite:markdown-wiki:table {
   columns: ['Class name','Description',],
   rows: [
     [
+        '`[Facebook\GraphNodes\GraphObject](/docs/php/GraphObject)`',
+        'The base collection object that represents a generic node.',
+    ],
+    [
+        '`[Facebook\GraphNodes\GraphList](/docs/php/GraphList)`',
+        'A list of GraphObject's with special methods to help paginate over the list.',
+    ],
+    [
       '`[Facebook\GraphNodes\GraphAlbum](/docs/php/GraphAlbum)`',
       'A collection that represents an album node.',
     ],
     [
       '`[Facebook\GraphNodes\GraphLocation](/docs/php/GraphLocation)`',
       'A collection that represents a location node.',
-    ],
-    [
-      '`[Facebook\GraphNodes\GraphObject](/docs/php/GraphObject)`',
-      'The base collection object that represents a generic node.',
     ],
     [
       '`[Facebook\GraphNodes\GraphPage](/docs/php/GraphPage)`',
@@ -139,10 +143,6 @@ FB(devsite:markdown-wiki:table {
     [
       '`[Facebook\GraphNodes\GraphUser](/docs/php/GraphUser)`',
       'A collection that represents a user node.',
-    ],
-    [
-      '`[Facebook\GraphNodes\GraphUserPage](/docs/php/GraphUserPage)`',
-      '*(Deprecated)* A collection that represents a user page node.',
     ],
   ],
 })

--- a/src/Facebook/Entities/AccessToken.php
+++ b/src/Facebook/Entities/AccessToken.php
@@ -343,9 +343,12 @@ class AccessToken implements \Serializable
       $app,
       $app->getAccessToken(),
       'GET',
-      $endpoint,
-      $params
+      $endpoint
     );
+    // We know what we're doing here.
+    // We want to send the access token as a param.
+    $request->dangerouslySetParams($params);
+
     return $client->sendRequest($request);
   }
 

--- a/src/Facebook/Entities/FacebookBatchRequest.php
+++ b/src/Facebook/Entities/FacebookBatchRequest.php
@@ -23,13 +23,16 @@
  */
 namespace Facebook\Entities;
 
+use ArrayIterator;
+use IteratorAggregate;
+use ArrayAccess;
 use Facebook\Exceptions\FacebookSDKException;
 
 /**
  * Class BatchRequest
  * @package Facebook
  */
-class FacebookBatchRequest extends FacebookRequest
+class FacebookBatchRequest extends FacebookRequest implements IteratorAggregate, ArrayAccess
 {
 
   /**
@@ -41,14 +44,14 @@ class FacebookBatchRequest extends FacebookRequest
    * Creates a new Request entity.
    *
    * @param FacebookApp|null $app
-   * @param AccessToken|string|null $accessToken
    * @param array $requests
+   * @param AccessToken|string|null $accessToken
    * @param string|null $graphVersion
    */
   public function __construct(
     FacebookApp $app = null,
-    $accessToken = null,
     array $requests = [],
+    $accessToken = null,
     $graphVersion = null
   )
   {
@@ -214,6 +217,48 @@ class FacebookBatchRequest extends FacebookRequest
     // @TODO Add support for JSONP with "callback"
 
     return $batch;
+  }
+
+  /**
+   * Get an iterator for the items.
+   *
+   * @return ArrayIterator
+   */
+  public function getIterator()
+  {
+    return new ArrayIterator($this->requests);
+  }
+
+  /**
+   * @return @inheritdoc
+   */
+  public function offsetSet($offset, $value)
+  {
+    $this->add($value, $offset);
+  }
+
+  /**
+   * @return @inheritdoc
+   */
+  public function offsetExists($offset)
+  {
+    return isset($this->requests[$offset]);
+  }
+
+  /**
+   * @return @inheritdoc
+   */
+  public function offsetUnset($offset)
+  {
+    unset($this->requests[$offset]);
+  }
+
+  /**
+   * @return @inheritdoc
+   */
+  public function offsetGet($offset)
+  {
+    return isset($this->requests[$offset]) ? $this->requests[$offset] : null;
   }
 
 }

--- a/src/Facebook/Entities/FacebookRequest.php
+++ b/src/Facebook/Entities/FacebookRequest.php
@@ -24,6 +24,7 @@
 namespace Facebook\Entities;
 
 use Facebook\Facebook;
+use Facebook\Url\FacebookUrlManipulator;
 use Facebook\Exceptions\FacebookSDKException;
 
 /**
@@ -114,6 +115,30 @@ class FacebookRequest
   }
 
   /**
+   * Sets the access token with one harvested from a URL or POST params.
+   *
+   * @param string $accessToken The access token.
+   *
+   * @return FacebookRequest
+   *
+   * @throws FacebookSDKException
+   */
+  public function setAccessTokenFromParams($accessToken)
+  {
+    $existingAccessToken = $this->getAccessToken();
+    if ( ! $existingAccessToken) {
+      $this->setAccessToken($accessToken);
+    } elseif ($accessToken !== $existingAccessToken) {
+      throw new FacebookSDKException(
+        'Access token mismatch. The access token provided in the FacebookRequest ' .
+        'and the one provided in the URL or POST params do not match.'
+      );
+    }
+
+    return $this;
+  }
+
+  /**
    * Return the access token for this request.
    *
    * @return string
@@ -141,6 +166,16 @@ class FacebookRequest
   public function getApp()
   {
     return $this->app;
+  }
+
+  /**
+   * Generate an app secret proof to sign this request.
+   *
+   * @return string
+   */
+  public function getAppSecretProof()
+  {
+    return AppSecretProof::make($this->getAccessToken(), $this->app->getSecret());
   }
 
   /**
@@ -210,10 +245,21 @@ class FacebookRequest
    * @param string
    *
    * @return FacebookRequest
+   *
+   * @throws FacebookSDKException
    */
   public function setEndpoint($endpoint)
   {
-    $this->endpoint = $endpoint;
+    // Harvest the access token from the endpoint to keep things in sync
+    $params = FacebookUrlManipulator::getParamsAsArray($endpoint);
+    if (isset($params['access_token'])) {
+      $this->setAccessTokenFromParams($params['access_token']);
+    }
+
+    // Clean the token & app secret proof from the endpoint.
+    $filterParams = ['access_token', 'appsecret_proof'];
+    $this->endpoint = FacebookUrlManipulator::removeParamsFromUrl($endpoint, $filterParams);
+
     return $this;
   }
 
@@ -260,12 +306,34 @@ class FacebookRequest
    * @param array $params
    *
    * @return FacebookRequest
+   *
+   * @throws FacebookSDKException
    */
   public function setParams(array $params = [])
   {
-    if (is_array($params)) {
-      $this->params = array_merge($this->params, $params);
+    if (isset($params['access_token'])) {
+      $this->setAccessTokenFromParams($params['access_token']);
     }
+
+    // Don't let these buggers slip in.
+    unset($params['access_token'], $params['appsecret_proof']);
+
+    $this->dangerouslySetParams($params);
+
+    return $this;
+  }
+
+  /**
+   * Set the params for this request without filtering them first.
+   *
+   * @param array $params
+   *
+   * @return FacebookRequest
+   */
+  public function dangerouslySetParams(array $params = [])
+  {
+    $this->params = array_merge($this->params, $params);
+
     return $this;
   }
 
@@ -278,11 +346,10 @@ class FacebookRequest
   {
     $params = $this->params;
 
-    if (!isset($params['access_token']) && $this->getAccessToken()) {
-      $params['access_token'] = $this->getAccessToken();
-    }
-    if (!isset($params['appsecret_proof']) && isset($params['access_token'])) {
-      $params['appsecret_proof'] = AppSecretProof::make($params['access_token'], $this->app->getSecret());
+    $accessToken = $this->getAccessToken();
+    if ($accessToken) {
+      $params['access_token'] = $accessToken;
+      $params['appsecret_proof'] = $this->getAppSecretProof();
     }
 
     return $params;
@@ -321,59 +388,17 @@ class FacebookRequest
   {
     $this->validateMethod();
 
-    $graphVersion = static::forceSlashPrefix($this->graphVersion);
-    $endpoint = static::forceSlashPrefix($this->getEndpoint());
+    $graphVersion = FacebookUrlManipulator::forceSlashPrefix($this->graphVersion);
+    $endpoint = FacebookUrlManipulator::forceSlashPrefix($this->getEndpoint());
 
     $url = $graphVersion.$endpoint;
 
     if ($this->getMethod() !== 'POST') {
       $params = $this->getParams();
-      $url = static::appendParamsToUrl($url, $params);
+      $url = FacebookUrlManipulator::appendParamsToUrl($url, $params);
     }
 
     return $url;
-  }
-
-  /**
-   * Gracefully appends params to the URL.
-   *
-   * @param string $url
-   * @param array $params
-   *
-   * @return string
-   */
-  public static function appendParamsToUrl($url, $params = [])
-  {
-    if (!$params) {
-      return $url;
-    }
-
-    if (strpos($url, '?') === false) {
-      return $url . '?' . http_build_query($params, null, '&');
-    }
-
-    list($path, $query_string) = explode('?', $url, 2);
-    parse_str($query_string, $query_array);
-
-    // Favor params from the original URL over $params
-    $params = array_merge($params, $query_array);
-
-    return $path . '?' . http_build_query($params, null, '&');
-  }
-
-  /**
-   * Check for a "/" prefix and prepend it if not exists.
-   *
-   * @param string|null $string
-   *
-   * @return string|null
-   */
-  public static function forceSlashPrefix($string)
-  {
-    if (!$string) {
-      return $string;
-    }
-    return strpos($string, '/') === 0 ? $string : '/'.$string;
   }
 
   /**

--- a/src/Facebook/Entities/FacebookResponse.php
+++ b/src/Facebook/Entities/FacebookResponse.php
@@ -28,7 +28,7 @@ use Facebook\Exceptions\FacebookResponseException;
 use Facebook\Exceptions\FacebookSDKException;
 
 /**
- * Class Response
+ * Class FacebookResponse
  * @package Facebook
  */
 class FacebookResponse
@@ -55,14 +55,9 @@ class FacebookResponse
   protected $decodedBody = [];
 
   /**
-   * @var string The access token that was used.
+   * @var FacebookRequest The original request that returned this response.
    */
-  protected $accessToken;
-
-  /**
-   * @var FacebookApp The facebook app entity.
-   */
-  protected $app;
+  protected $request;
 
   /**
    * @var FacebookSDKException The exception thrown by this request.
@@ -72,27 +67,34 @@ class FacebookResponse
   /**
    * Creates a new Response entity.
    *
-   * @param FacebookApp $app
+   * @param FacebookRequest $request
+   * @param string|null $body
    * @param int|null $httpStatusCode
    * @param array|null $headers
-   * @param string|null $body
-   * @param string|null $accessToken
    */
   public function __construct(
-    FacebookApp $app,
-    $httpStatusCode = null,
-    array $headers = [],
+    FacebookRequest $request,
     $body = null,
-    $accessToken = null
+    $httpStatusCode = null,
+    array $headers = []
   )
   {
-    $this->app = $app;
+    $this->request = $request;
+    $this->body = $body;
     $this->httpStatusCode = $httpStatusCode;
     $this->headers = $headers;
-    $this->body = $body;
-    $this->accessToken = $accessToken;
 
     $this->decodeBody();
+  }
+
+  /**
+   * Return the original request that returned this response.
+   *
+   * @return FacebookRequest
+   */
+  public function getRequest()
+  {
+    return $this->request;
   }
 
   /**
@@ -102,7 +104,7 @@ class FacebookResponse
    */
   public function getApp()
   {
-    return $this->app;
+    return $this->request->getApp();
   }
 
   /**
@@ -112,7 +114,7 @@ class FacebookResponse
    */
   public function getAccessToken()
   {
-    return $this->accessToken;
+    return $this->request->getAccessToken();
   }
 
   /**
@@ -162,7 +164,7 @@ class FacebookResponse
    */
   public function getAppSecretProof()
   {
-    return AppSecretProof::make($this->accessToken, $this->app->getSecret());
+    return $this->request->getAppSecretProof();
   }
 
   /**

--- a/src/Facebook/FacebookClient.php
+++ b/src/Facebook/FacebookClient.php
@@ -152,17 +152,14 @@ class FacebookClient
 
     // Should throw `FacebookSDKException` exception on HTTP client error.
     // Don't catch to allow it to bubble up.
-    $response = $this->httpClientHandler->send($url, $method, $params, $headers);
+    $responseBody = $this->httpClientHandler->send($url, $method, $params, $headers);
 
     static::$requestCount++;
 
     $httpResponseCode = $this->httpClientHandler->getResponseHttpStatusCode();
     $httpResponseHeaders = $this->httpClientHandler->getResponseHeaders();
 
-    $accessToken = $request->getAccessToken();
-    $app = $request->getApp();
-
-    $returnResponse = new FacebookResponse($app, $httpResponseCode, $httpResponseHeaders, $response, $accessToken);
+    $returnResponse = new FacebookResponse($request, $responseBody, $httpResponseCode, $httpResponseHeaders);
 
     if ($returnResponse->isError()) {
       throw $returnResponse->getThrownException();
@@ -185,7 +182,7 @@ class FacebookClient
     $request->prepareRequestsForBatch();
     $facebookResponse = $this->sendRequest($request);
 
-    return new FacebookBatchResponse($facebookResponse);
+    return new FacebookBatchResponse($request, $facebookResponse);
   }
 
 }

--- a/src/Facebook/GraphNodes/GraphList.php
+++ b/src/Facebook/GraphNodes/GraphList.php
@@ -23,6 +23,10 @@
  */
 namespace Facebook\GraphNodes;
 
+use Facebook\Entities\FacebookRequest;
+use Facebook\Url\FacebookUrlManipulator;
+use Facebook\Exceptions\FacebookSDKException;
+
 /**
  * Class GraphList
  * @package Facebook
@@ -31,39 +35,166 @@ class GraphList extends Collection
 {
 
   /**
-   * @var array $metaData An array of Graph meta data like pagination, etc.
+   * @var FacebookRequest The original request that generated this data.
+   */
+  protected $request;
+
+  /**
+   * @var array An array of Graph meta data like pagination, etc.
    */
   protected $metaData = [];
 
   /**
+   * @var string|null The parent Graph edge endpoint that generated the list.
+   */
+  protected $parentEdgeEndpoint;
+
+  /**
+   * @var string|null The subclass of the child GraphObject's.
+   */
+  protected $subclassName;
+
+  /**
    * Init this collection of GraphObject's.
    *
+   * @param FacebookRequest $request The original request that generated this data.
    * @param array $data An array of GraphObject's.
    * @param array $metaData An array of Graph meta data like pagination, etc.
+   * @param string|null $parentEdgeEndpoint The parent Graph edge endpoint that generated the list.
+   * @param string|null $subclassName The subclass of the child GraphObject's.
    */
-  public function __construct(array $data = [], array $metaData = [])
+  public function __construct(FacebookRequest $request, array $data = [], array $metaData = [], $parentEdgeEndpoint = null, $subclassName = null)
   {
+    $this->request = $request;
     $this->metaData = $metaData;
+    $this->parentEdgeEndpoint = $parentEdgeEndpoint;
+    $this->subclassName = $subclassName;
 
     parent::__construct($data);
   }
 
   /**
-   * Get the next page of results of this list of Graph objects.
+   * Gets the parent Graph edge endpoint that generated the list.
    *
-   * @TODO
+   * @return string|null
    */
-  public function next()
+  public function getParentGraphEdge()
   {
+    return $this->parentEdgeEndpoint;
   }
 
   /**
-   * Get the previous page of results of this list of Graph objects.
+   * Gets the subclass name that the child GraphObject's are cast as.
    *
-   * @TODO
+   * @return string|null
    */
-  public function previous()
+  public function getSubClassName()
   {
+    return $this->subclassName;
+  }
+
+  /**
+   * Generates a pagination URL based on a cursor.
+   *
+   * @param string $direction The direction of the page: next|previous
+   *
+   * @return string|null
+   *
+   * @throws FacebookSDKException
+   */
+  public function getPaginationUrl($direction)
+  {
+    $this->validateForPagination();
+
+    // Do we have a paging URL?
+    if (isset($this->metaData['paging'][$direction])) {
+      // Graph returns the full URL with all the original params.
+      // We just want the endpoint though.
+      $pageUrl = $this->metaData['paging'][$direction];
+      return FacebookUrlManipulator::baseGraphUrlEndpoint($pageUrl);
+    }
+
+    // Do we have a cursor to work with?
+    $cursorDirection = $direction === 'next' ? 'after' : 'before';
+    if ( ! isset($this->metaData['paging']['cursors'][$cursorDirection])) {
+      return null;
+    }
+
+    // If we don't know the ID of the parent node, this ain't gonna work.
+    if ( ! $this->parentEdgeEndpoint) {
+      return null;
+    }
+
+    // We have the parent node ID, paging cursor & original request.
+    // These were the ingredients chosen to create the perfect little URL.
+    $cursor = $this->metaData['paging']['cursors'][$cursorDirection];
+
+    $pageUrl = $this->parentEdgeEndpoint . '?' . $cursorDirection . '=' . urlencode($cursor);
+
+    // Pull in the original params
+    $originalUrl = $this->request->getUrl();
+    $pageUrl = FacebookUrlManipulator::mergeUrlParams($originalUrl, $pageUrl);
+
+    return FacebookUrlManipulator::forceSlashPrefix($pageUrl);
+  }
+
+  /**
+   * Validates whether or not we can paginate on this request.
+   *
+   * @throws FacebookSDKException
+   */
+  public function validateForPagination()
+  {
+    if ($this->request->getMethod() !== 'GET') {
+      throw new FacebookSDKException(
+        'You can only paginate on a GET request.', 720
+      );
+    }
+  }
+
+  /**
+   * Gets the request object needed to make a next|previous page request.
+   *
+   * @param string $direction The direction of the page: next|previous
+   *
+   * @return FacebookRequest|null
+   *
+   * @throws FacebookSDKException
+   */
+  public function getPaginationRequest($direction)
+  {
+    $pageUrl = $this->getPaginationUrl($direction);
+    if ( ! $pageUrl) {
+      return null;
+    }
+
+    $newRequest = clone $this->request;
+    $newRequest->setEndpoint($pageUrl);
+    return $newRequest;
+  }
+
+  /**
+   * Gets the request object needed to make a "next" page request.
+   *
+   * @return FacebookRequest|null
+   *
+   * @throws FacebookSDKException
+   */
+  public function getNextPageRequest()
+  {
+    return $this->getPaginationRequest('next');
+  }
+
+  /**
+   * Gets the request object needed to make a "previous" page request.
+   *
+   * @return FacebookRequest|null
+   *
+   * @throws FacebookSDKException
+   */
+  public function getPreviousPageRequest()
+  {
+    return $this->getPaginationRequest('previous');
   }
 
 }

--- a/src/Facebook/GraphNodes/GraphObjectFactory.php
+++ b/src/Facebook/GraphNodes/GraphObjectFactory.php
@@ -46,12 +46,17 @@ class GraphObjectFactory
   /**
    * @const string The base graph object class.
    */
-  const BASE_GRAPH_OBJECT_CLASS = '\\Facebook\\GraphNodes\\GraphObject';
+  const BASE_GRAPH_OBJECT_CLASS = '\Facebook\GraphNodes\GraphObject';
 
   /**
    * @const string The graph object prefix.
    */
-  const BASE_GRAPH_OBJECT_PREFIX = '\\Facebook\\GraphNodes\\';
+  const BASE_GRAPH_OBJECT_PREFIX = '\Facebook\GraphNodes\\';
+
+  /**
+   * @var FacebookResponse The response entity from Graph.
+   */
+  protected $response;
 
   /**
    * @var array The decoded body of the FacebookResponse entity from Graph.
@@ -65,6 +70,7 @@ class GraphObjectFactory
    */
   public function __construct(FacebookResponse $response)
   {
+    $this->response = $response;
     $this->decodedBody = $response->getDecodedBody();
   }
 
@@ -82,12 +88,7 @@ class GraphObjectFactory
     $this->validateResponseAsArray();
     $this->validateResponseCastableAsGraphObject();
 
-    // Sometimes Graph is a weirdo and returns a GraphObject under the "data" key
-    if (isset($this->decodedBody['data'])) {
-      $this->decodedBody = $this->decodedBody['data'];
-    }
-
-    return $this->safelyMakeGraphObject($this->decodedBody, $subclassName);
+    return $this->castAsGraphObjectOrGraphList($this->decodedBody, $subclassName);
   }
 
   /**
@@ -157,7 +158,7 @@ class GraphObjectFactory
       $subclassName = static::BASE_GRAPH_OBJECT_PREFIX . $subclassName;
     }
 
-    return $this->safelyMakeGraphList($this->decodedBody, $subclassName);
+    return $this->castAsGraphObjectOrGraphList($this->decodedBody, $subclassName);
   }
 
   /**
@@ -223,6 +224,9 @@ class GraphObjectFactory
     $subclassName = $subclassName ?: static::BASE_GRAPH_OBJECT_CLASS;
     static::validateSubclass($subclassName);
 
+    // Remember the parent node ID
+    $parentNodeId = isset($data['id']) ? $data['id'] : null;
+
     $items = [];
 
     foreach ($data as $k => $v) {
@@ -237,7 +241,7 @@ class GraphObjectFactory
           : null;
 
         // Could be a GraphList or GraphObject
-        $items[$k] = $this->castAsGraphObjectOrGraphList($v, $objectSubClass);
+        $items[$k] = $this->castAsGraphObjectOrGraphList($v, $objectSubClass, $k, $parentNodeId);
       } else {
         $items[$k] = $v;
       }
@@ -251,17 +255,19 @@ class GraphObjectFactory
    *
    * @param array $data The array of data to iterate over.
    * @param string|null $subclassName The subclass to cast this collection to.
+   * @param string|null $parentKey The key of this data (Graph edge).
+   * @param string|null $parentNodeId The parent Graph node ID.
    *
    * @return GraphObject|GraphList
    *
    * @throws FacebookSDKException
    */
-  public function castAsGraphObjectOrGraphList(array $data, $subclassName = null)
+  public function castAsGraphObjectOrGraphList(array $data, $subclassName = null, $parentKey = null, $parentNodeId = null)
   {
     if (isset($data['data'])) {
       // Create GraphList
       if (static::isCastableAsGraphList($data['data'])) {
-        return $this->safelyMakeGraphList($data, $subclassName);
+        return $this->safelyMakeGraphList($data, $subclassName, $parentKey, $parentNodeId);
       }
       // Sometimes Graph is a weirdo and returns a GraphObject under the "data" key
       $data = $data['data'];
@@ -276,12 +282,14 @@ class GraphObjectFactory
    *
    * @param array $data The array of data to iterate over.
    * @param string|null $subclassName The GraphObject subclass to cast each item in the list to.
+   * @param string|null $parentKey The key of this data (Graph edge).
+   * @param string|null $parentNodeId The parent Graph node ID.
    *
    * @return GraphList
    *
    * @throws FacebookSDKException
    */
-  public function safelyMakeGraphList(array $data, $subclassName = null)
+  public function safelyMakeGraphList(array $data, $subclassName = null, $parentKey = null, $parentNodeId = null)
   {
     if ( ! isset($data['data'])) {
       throw new FacebookSDKException(
@@ -291,13 +299,32 @@ class GraphObjectFactory
 
     $dataList = [];
     foreach ($data['data'] as $graphNode) {
-      $dataList[] = $this->safelyMakeGraphObject($graphNode, $subclassName);
+      $dataList[] = $this->safelyMakeGraphObject($graphNode, $subclassName, $parentKey, $parentNodeId);
     }
 
-    // @TODO: Look for meta data here
-    $metaData = [];
+    $metaData = $this->getMetaData($data);
 
-    return new GraphList($dataList, $metaData);
+    // We'll need to make an edge endpoint for this in case it's a GraphList (for cursor pagination)
+    $parentGraphEdgeEndpoint = $parentNodeId && $parentKey ? '/' . $parentNodeId . '/' . $parentKey : null;
+    
+    return new GraphList($this->response->getRequest(), $dataList, $metaData, $parentGraphEdgeEndpoint, $subclassName);
+  }
+
+  /**
+   * Get the meta data from a list in a Graph response.
+   *
+   * @param array $data The Graph response.
+   *
+   * @return array
+   */
+  public function getMetaData(array $data)
+  {
+    $meta_data = [];
+    if (isset($data['paging'])) {
+      $meta_data['paging'] = $data['paging'];
+    }
+
+    return $meta_data;
   }
 
   /**

--- a/src/Facebook/Url/FacebookUrlManipulator.php
+++ b/src/Facebook/Url/FacebookUrlManipulator.php
@@ -57,11 +57,110 @@ class FacebookUrlManipulator
       }
     }
 
+    $scheme = isset($parts['scheme']) ? $parts['scheme'] . '://' : '';
+    $host = isset($parts['host']) ? $parts['host'] : '';
     $port = isset($parts['port']) ? ':' . $parts['port'] : '';
     $path = isset($parts['path']) ? $parts['path'] : '';
     $fragment = isset($parts['fragment']) ? '#' . $parts['fragment'] : '';
 
-    return $parts['scheme'] . '://' . $parts['host'] . $port . $path . $query . $fragment;
+    return $scheme . $host . $port . $path . $query . $fragment;
+  }
+
+  /**
+   * Gracefully appends params to the URL.
+   *
+   * @param string $url The URL that will receive the params.
+   * @param array $newParams The params to append to the URL.
+   *
+   * @return string
+   */
+  public static function appendParamsToUrl($url, array $newParams = [])
+  {
+    if ( ! $newParams) {
+      return $url;
+    }
+
+    if (strpos($url, '?') === false) {
+      return $url . '?' . http_build_query($newParams, null, '&');
+    }
+
+    list($path, $query) = explode('?', $url, 2);
+    $existingParams = [];
+    parse_str($query, $existingParams);
+
+    // Favor params from the original URL over $newParams
+    $newParams = array_merge($newParams, $existingParams);
+
+    // Sort for a predicable order
+    ksort($newParams);
+
+    return $path . '?' . http_build_query($newParams, null, '&');
+  }
+
+  /**
+   * Returns the params from a URL in the form of an array.
+   *
+   * @param string $url The URL to parse the params from.
+   *
+   * @return array
+   */
+  public static function getParamsAsArray($url)
+  {
+    $query = parse_url($url, PHP_URL_QUERY);
+    if ( ! $query) {
+      return [];
+    }
+    $params = [];
+    parse_str($query, $params);
+
+    return $params;
+  }
+
+  /**
+   * Adds the params of the first URL to the second URL.
+   * Any params that already exist in the second URL will go untouched.
+   *
+   * @param string $urlToStealFrom The URL harvest the params from.
+   * @param string $urlToAddTo The URL that will receive the new params.
+   *
+   * @return string The $urlToAddTo with any new params from $urlToStealFrom.
+   */
+  public static function mergeUrlParams($urlToStealFrom, $urlToAddTo)
+  {
+    $newParams = static::getParamsAsArray($urlToStealFrom);
+    // Nothing new to add, return as-is
+    if ( ! $newParams) {
+      return $urlToAddTo;
+    }
+
+    return static::appendParamsToUrl($urlToAddTo, $newParams);
+  }
+
+  /**
+   * Check for a "/" prefix and prepend it if not exists.
+   *
+   * @param string|null $string
+   *
+   * @return string|null
+   */
+  public static function forceSlashPrefix($string)
+  {
+    if (!$string) {
+      return $string;
+    }
+    return strpos($string, '/') === 0 ? $string : '/' . $string;
+  }
+
+  /**
+   * Trims off the hostname and Graph version from a URL.
+   *
+   * @param string $urlToTrim The URL the needs the surgery.
+   *
+   * @return string The $urlToTrim with the hostname and Graph version removed.
+   */
+  public static function baseGraphUrlEndpoint($urlToTrim)
+  {
+    return '/' . preg_replace('/^https:\/\/.+\.facebook\.com(\/v.+?)?\//', '', $urlToTrim);
   }
 
 }

--- a/tests/Entities/FacebookBatchRequestTest.php
+++ b/tests/Entities/FacebookBatchRequestTest.php
@@ -31,6 +31,9 @@ use Facebook\Entities\FacebookBatchRequest;
 class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
 {
 
+  /**
+   * @var FacebookApp
+   */
   private $app;
 
   public function setUp()
@@ -40,7 +43,7 @@ class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
 
   public function testABatchRequestWillInstantiateWithTheProperProperties()
   {
-    $batchRequest = new FacebookBatchRequest($this->app, 'foo_token', [], 'v0.1337');
+    $batchRequest = new FacebookBatchRequest($this->app, [], 'foo_token', 'v0.1337');
 
     $this->assertSame($this->app, $batchRequest->getApp());
     $this->assertEquals('foo_token', $batchRequest->getAccessToken());
@@ -159,7 +162,7 @@ class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
       new FacebookRequest(null, null, 'DELETE', '/baz'),
     ];
 
-    $batchRequest = new FacebookBatchRequest($this->app, 'foo_token', $requests);
+    $batchRequest = new FacebookBatchRequest($this->app, $requests, 'foo_token');
     $formattedRequests = $batchRequest->getRequests();
 
     $this->assertRequestsMatch($requests, $formattedRequests);
@@ -170,7 +173,7 @@ class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
    */
   public function testAZeroRequestCountWithThrow()
   {
-    $batchRequest = new FacebookBatchRequest($this->app, 'foo_token');
+    $batchRequest = new FacebookBatchRequest($this->app, [], 'foo_token');
 
     $batchRequest->validateBatchRequestCount();
   }
@@ -294,7 +297,7 @@ class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
 
   private function createBatchRequest()
   {
-    return new FacebookBatchRequest($this->app, 'foo_token');
+    return new FacebookBatchRequest($this->app, [], 'foo_token');
   }
 
   private function createBatchRequestWithRequests(array $requests)

--- a/tests/Entities/FacebookBatchResponseTest.php
+++ b/tests/Entities/FacebookBatchResponseTest.php
@@ -24,11 +24,36 @@
 namespace Facebook\Tests\Entities;
 
 use Facebook\Entities\FacebookApp;
+use Facebook\Entities\FacebookRequest;
 use Facebook\Entities\FacebookResponse;
+use Facebook\Entities\FacebookBatchRequest;
 use Facebook\Entities\FacebookBatchResponse;
 
 class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
 {
+
+  /**
+   * @var \Facebook\Entities\FacebookApp
+   */
+  protected $app;
+
+  /**
+   * @var \Facebook\Entities\FacebookRequest
+   */
+  protected $request;
+
+  public function setUp()
+  {
+    $this->app = new FacebookApp('123', 'foo_secret');
+    $this->request = new FacebookRequest(
+      $this->app,
+      'foo_token',
+      'POST',
+      '/',
+      ['batch' => 'foo'],
+      'foo_eTag',
+      'v1337');
+  }
 
   public function testASuccessfulJsonBatchResponseWillBeDecoded()
   {
@@ -37,18 +62,19 @@ class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
     $graphResponseJson .= '{"code":200,"headers":[{"name":"Connection","value":"close"},{"name":"Last-Modified","value":"2013-12-24T00:34:20+0000"},{"name":"Facebook-API-Version","value":"v2.0"},{"name":"ETag","value":"\"fooTag\""},{"name":"Content-Type","value":"text\/javascript; charset=UTF-8"},{"name":"Pragma","value":"no-cache"},{"name":"Access-Control-Allow-Origin","value":"*"},{"name":"Cache-Control","value":"private, no-cache, no-store, must-revalidate"},{"name":"Expires","value":"Sat, 01 Jan 2000 00:00:00 GMT"}],"body":"{\"id\":\"123\",\"name\":\"Foo McBar\",\"updated_time\":\"2013-12-24T00:34:20+0000\",\"verified\":true}"}';
     // Paginated list of Graph objects.
     $graphResponseJson .= ',{"code":200,"headers":[{"name":"Connection","value":"close"},{"name":"Facebook-API-Version","value":"v1.0"},{"name":"ETag","value":"\"barTag\""},{"name":"Content-Type","value":"text\/javascript; charset=UTF-8"},{"name":"Pragma","value":"no-cache"},{"name":"Access-Control-Allow-Origin","value":"*"},{"name":"Cache-Control","value":"private, no-cache, no-store, must-revalidate"},{"name":"Expires","value":"Sat, 01 Jan 2000 00:00:00 GMT"}],"body":"{\"data\":[{\"id\":\"1337\",\"story\":\"Foo story.\"},{\"id\":\"1338\",\"story\":\"Bar story.\"}],\"paging\":{\"previous\":\"previous_url\",\"next\":\"next_url\"}}"}';
-    // Endpoint not found.
-    //$graphResponseJson .= ',{"code":404,"headers":[{"name":"Connection","value":"close"},{"name":"WWW-Authenticate","value":"OAuth \"Facebook Platform\" \"not_found\" \"(#803) Cannot query users by their username (foo)\""},{"name":"Facebook-API-Version","value":"v2.0"},{"name":"Content-Type","value":"text\/javascript; charset=UTF-8"},{"name":"Pragma","value":"no-cache"},{"name":"Access-Control-Allow-Origin","value":"*"},{"name":"Cache-Control","value":"no-store"},{"name":"Expires","value":"Sat, 01 Jan 2000 00:00:00 GMT"}],"body":"{\"error\":{\"message\":\"(#803) Cannot query users by their username (foo)\",\"type\":\"OAuthException\",\"code\":803}}"}';
-    // Invalid access token.
-    //$graphResponseJson .= ',{"code":400,"headers":[{"name":"Connection","value":"close"},{"name":"Expires","value":"Sat, 01 Jan 2000 00:00:00 GMT"},{"name":"Cache-Control","value":"no-store"},{"name":"Access-Control-Allow-Origin","value":"*"},{"name":"Pragma","value":"no-cache"},{"name":"Content-Type","value":"text\/javascript; charset=UTF-8"},{"name":"WWW-Authenticate","value":"OAuth \"Facebook Platform\" \"invalid_token\" \"Invalid OAuth access token.\""}],"body":"{\"error\":{\"message\":\"Invalid OAuth access token.\",\"type\":\"OAuthException\",\"code\":190}}"}';
     // After POST operation.
     $graphResponseJson .= ',{"code":200,"headers":[{"name":"Connection","value":"close"},{"name":"Expires","value":"Sat, 01 Jan 2000 00:00:00 GMT"},{"name":"Cache-Control","value":"private, no-cache, no-store, must-revalidate"},{"name":"Access-Control-Allow-Origin","value":"*"},{"name":"Pragma","value":"no-cache"},{"name":"Content-Type","value":"text\/javascript; charset=UTF-8"},{"name":"Facebook-API-Version","value":"v2.0"}],"body":"{\"id\":\"123_1337\"}"}';
     // After DELETE operation.
     $graphResponseJson .= ',{"code":200,"headers":[{"name":"Connection","value":"close"},{"name":"Expires","value":"Sat, 01 Jan 2000 00:00:00 GMT"},{"name":"Cache-Control","value":"private, no-cache, no-store, must-revalidate"},{"name":"Access-Control-Allow-Origin","value":"*"},{"name":"Pragma","value":"no-cache"},{"name":"Content-Type","value":"text\/javascript; charset=UTF-8"},{"name":"Facebook-API-Version","value":"v2.0"}],"body":"true"}';
     $graphResponseJson .= ']';
-    $app = new FacebookApp('123', 'foo_secret');
-    $response = new FacebookResponse($app, 200, [], $graphResponseJson);
-    $batchResponse = new FacebookBatchResponse($response);
+    $response = new FacebookResponse($this->request, $graphResponseJson, 200);
+    $batchRequest = new FacebookBatchRequest($this->app, [
+        new FacebookRequest($this->app, 'token'),
+        new FacebookRequest($this->app, 'token'),
+        new FacebookRequest($this->app, 'token'),
+        new FacebookRequest($this->app, 'token'),
+      ]);
+    $batchResponse = new FacebookBatchResponse($batchRequest, $response);
 
     $decodedResponses = $batchResponse->getResponses();
 
@@ -60,20 +86,6 @@ class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
     $graphList = $decodedResponses[1]->getGraphList();
     $this->assertInstanceOf('Facebook\GraphNodes\GraphObject', $graphList[0]);
     $this->assertInstanceOf('Facebook\GraphNodes\GraphObject', $graphList[1]);
-    /*
-    // Endpoint not found.
-    $this->assertTrue($decodedResponses[2]->isError(), 'Expected Response to return an error for endpoint not found.');
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookResponseException', $decodedResponses[2]->getThrownException());
-    // Invalid access token.
-    $this->assertTrue($decodedResponses[3]->isError(), 'Expected Response to return an error for invalid access token.');
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookResponseException', $decodedResponses[3]->getThrownException());
-    // After POST operation.
-    $this->assertFalse($decodedResponses[4]->isError(), 'Did not expect Response to return an error for POST operation.');
-    $this->assertInstanceOf('Facebook\GraphNodes\GraphObject', $decodedResponses[4]->getGraphObject());
-    // After DELETE operation.
-    $this->assertFalse($decodedResponses[5]->isError(), 'Did not expect Response to return an error for DELETE operation.');
-    $this->assertInstanceOf('Facebook\GraphNodes\GraphObject', $decodedResponses[5]->getGraphObject());
-    */
   }
 
 
@@ -84,15 +96,45 @@ class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
     $graphResponseJson .= ',{"code":200,"headers":[],"body":"{\"foo\":\"bar\"}"}';
     $graphResponseJson .= ',{"code":200,"headers":[],"body":"{\"foo\":\"bar\"}"}';
     $graphResponseJson .= ']';
-    $app = new FacebookApp('123', 'foo_secret');
-    $response = new FacebookResponse($app, 200, [], $graphResponseJson);
-    $batchResponse = new FacebookBatchResponse($response);
+    $response = new FacebookResponse($this->request, $graphResponseJson, 200);
+    $batchRequest = new FacebookBatchRequest($this->app, [
+        'req_one' => new FacebookRequest($this->app, 'token'),
+        'req_two' => new FacebookRequest($this->app, 'token'),
+        'req_three' => new FacebookRequest($this->app, 'token'),
+      ]);
+    $batchResponse = new FacebookBatchResponse($batchRequest, $response);
 
     $this->assertInstanceOf('IteratorAggregate', $batchResponse);
 
-    foreach ($batchResponse as $responseEntity) {
+    foreach ($batchResponse as $key => $responseEntity) {
+      $this->assertTrue(in_array($key, ['req_one', 'req_two', 'req_three']));
       $this->assertInstanceOf('Facebook\Entities\FacebookResponse', $responseEntity);
     }
+  }
+
+  public function testTheOriginalRequestCanBeObtainedForEachRequest()
+  {
+    $graphResponseJson = '[';
+    $graphResponseJson .= '{"code":200,"headers":[],"body":"{\"foo\":\"bar\"}"}';
+    $graphResponseJson .= ',{"code":200,"headers":[],"body":"{\"foo\":\"bar\"}"}';
+    $graphResponseJson .= ',{"code":200,"headers":[],"body":"{\"foo\":\"bar\"}"}';
+    $graphResponseJson .= ']';
+    $response = new FacebookResponse($this->request, $graphResponseJson, 200);
+
+    $requests = [
+      new FacebookRequest($this->app, 'foo_token_one', 'GET', '/me'),
+      new FacebookRequest($this->app, 'foo_token_two', 'POST', '/you'),
+      new FacebookRequest($this->app, 'foo_token_three', 'DELETE', '/123456'),
+    ];
+
+    $batchRequest = new FacebookBatchRequest($this->app, $requests);
+    $batchResponse = new FacebookBatchResponse($batchRequest, $response);
+
+    $this->assertInstanceOf('Facebook\Entities\FacebookResponse', $batchResponse[0]);
+    $this->assertInstanceOf('Facebook\Entities\FacebookRequest', $batchResponse[0]->getRequest());
+    $this->assertEquals('foo_token_one', $batchResponse[0]->getAccessToken());
+    $this->assertEquals('foo_token_two', $batchResponse[1]->getAccessToken());
+    $this->assertEquals('foo_token_three', $batchResponse[2]->getAccessToken());
   }
 
 }

--- a/tests/FacebookClientTest.php
+++ b/tests/FacebookClientTest.php
@@ -102,7 +102,6 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
 
   public function testAFacebookRequestEntityCanBeUsedToSendARequestToGraph()
   {
-    $facebookApp = new FacebookApp('123', 'foo_secret');
     $facebookRequest = m::mock('Facebook\Entities\FacebookRequest');
     $facebookRequest
       ->shouldReceive('getUrl')
@@ -120,14 +119,6 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
       ->shouldReceive('getHeaders')
       ->once()
       ->andReturn(['request_header' => 'foo']);
-    $facebookRequest
-      ->shouldReceive('getAccessToken')
-      ->once()
-      ->andReturn('foo_token');
-    $facebookRequest
-      ->shouldReceive('getApp')
-      ->once()
-      ->andReturn($facebookApp);
 
     $this->httpClientMock
       ->shouldReceive('send')
@@ -151,7 +142,6 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
 
   public function testAFacebookBatchRequestEntityCanBeUsedToSendABatchRequestToGraph()
   {
-    $facebookApp = new FacebookApp('123', 'foo_secret');
     $facebookBatchRequest = m::mock('Facebook\Entities\FacebookBatchRequest');
     $facebookBatchRequest
       ->shouldReceive('prepareRequestsForBatch')
@@ -173,14 +163,6 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
       ->shouldReceive('getHeaders')
       ->once()
       ->andReturn(['request_header' => 'foo']);
-    $facebookBatchRequest
-      ->shouldReceive('getAccessToken')
-      ->once()
-      ->andReturn('foo_token');
-    $facebookBatchRequest
-      ->shouldReceive('getApp')
-      ->once()
-      ->andReturn($facebookApp);
 
     $this->httpClientMock
       ->shouldReceive('send')

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -23,18 +23,21 @@
  */
 namespace Facebook\Tests;
 
-use Mockery as m;
 use Facebook\Facebook;
 use Facebook\FacebookClient;
 use Facebook\HttpClients\FacebookHttpClientInterface;
 use Facebook\PersistentData\PersistentDataInterface;
 use Facebook\Url\UrlDetectionInterface;
+use Facebook\Entities\FacebookRequest;
+use Facebook\GraphNodes\GraphList;
 
 class FooClientInterface implements FacebookHttpClientInterface
 {
   public function getResponseHeaders() { return ['X-foo-header' => 'bar']; }
   public function getResponseHttpStatusCode() { return 1337; }
-  public function send($url, $method = 'GET', array $parameters = [], array $headers = []) { return 'foo_response'; }
+  public function send($url, $method = 'GET', array $parameters = [], array $headers = []) {
+    return '{"data":[{"id":"123","name":"Foo"},{"id":"1337","name":"Bar"}]}';
+  }
 }
 
 class FooPersistentDataInterface implements PersistentDataInterface
@@ -193,6 +196,38 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
     $this->assertEquals('foo_secret', $request->getApp()->getSecret());
     $this->assertEquals('foo_token', (string) $request->getAccessToken());
     $this->assertEquals('v1337', $request->getGraphVersion());
+  }
+
+  public function testPaginationReturnsProperResponse()
+  {
+    $config = array_merge($this->config, [
+        'http_client_handler' => new FooClientInterface(),
+      ]);
+    $fb = new Facebook($config);
+
+    $request = new FacebookRequest($fb->getApp(), 'foo_token', 'GET');
+    $graphList = new GraphList(
+      $request,
+      [],
+      [
+        'paging' => [
+          'cursors' => [
+            'after' => 'bar_after_cursor',
+            'before' => 'bar_before_cursor',
+          ],
+        ]
+      ],
+      '/1337/photos',
+      '\Facebook\GraphNodes\GraphUser');
+
+    $nextPage = $fb->next($graphList);
+    $this->assertInstanceOf('Facebook\GraphNodes\GraphList', $nextPage);
+    $this->assertInstanceOf('Facebook\GraphNodes\GraphUser', $nextPage[0]);
+    $this->assertEquals('Foo', $nextPage[0]['name']);
+
+    $lastResponse = $fb->getLastResponse();
+    $this->assertInstanceOf('Facebook\Entities\FacebookResponse', $lastResponse);
+    $this->assertEquals(1337, $lastResponse->getHttpStatusCode());
   }
 
 }

--- a/tests/GraphNodes/GraphListTest.php
+++ b/tests/GraphNodes/GraphListTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\GraphNodes;
+
+use Facebook\Entities\FacebookApp;
+use Facebook\Entities\FacebookRequest;
+use Facebook\GraphNodes\GraphList;
+
+class GraphListTest extends \PHPUnit_Framework_TestCase
+{
+
+  /**
+   * @var \Facebook\Entities\FacebookRequest
+   */
+  protected $request;
+
+  protected $basePagination = [
+    'next' => 'https://graph.facebook.com/v7.12/998899/photos?pretty=0&limit=25&after=foo_after_cursor',
+    'previous' => 'https://graph.facebook.com/v7.12/998899/photos?pretty=0&limit=25&before=foo_before_cursor',
+  ];
+  protected $cursorPagination = [
+    'cursors' => [
+      'after' => 'bar_after_cursor',
+      'before' => 'bar_before_cursor',
+    ],
+  ];
+
+  public function setUp()
+  {
+    $app = new FacebookApp('123', 'foo_app_secret');
+    $this->request = new FacebookRequest(
+      $app,
+      'foo_token',
+      'GET',
+      '/me/photos?keep=me',
+      ['foo' => 'bar'],
+      'foo_eTag',
+      'v1337');
+  }
+
+  /**
+   * @expectedException \Facebook\Exceptions\FacebookSDKException
+   */
+  public function testNonGetRequestsWillThrow()
+  {
+    $this->request->setMethod('POST');
+    $graphList = new GraphList($this->request);
+    $graphList->validateForPagination();
+  }
+
+  public function testCanReturnGraphGeneratedPaginationEndpoints()
+  {
+    $graphList = new GraphList(
+      $this->request,
+      [],
+      ['paging' => $this->basePagination]);
+    $nextPage = $graphList->getPaginationUrl('next');
+    $prevPage = $graphList->getPaginationUrl('previous');
+
+    $this->assertEquals('/998899/photos?pretty=0&limit=25&after=foo_after_cursor', $nextPage);
+    $this->assertEquals('/998899/photos?pretty=0&limit=25&before=foo_before_cursor', $prevPage);
+  }
+
+  public function testCanGeneratePaginationEndpointsFromACursor()
+  {
+    $graphList = new GraphList(
+      $this->request,
+      [],
+      ['paging' => $this->cursorPagination],
+      '/1234567890/likes');
+    $nextPage = $graphList->getPaginationUrl('next');
+    $prevPage = $graphList->getPaginationUrl('previous');
+
+    $this->assertEquals('/1234567890/likes?access_token=foo_token&after=bar_after_cursor&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&foo=bar&keep=me', $nextPage);
+    $this->assertEquals('/1234567890/likes?access_token=foo_token&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&before=bar_before_cursor&foo=bar&keep=me', $prevPage);
+  }
+
+  public function testCanInstantiateNewPaginationRequest()
+  {
+    $graphList = new GraphList(
+      $this->request,
+      [],
+      ['paging' => $this->cursorPagination],
+      '/1234567890/likes');
+    $nextPage = $graphList->getNextPageRequest();
+    $prevPage = $graphList->getPreviousPageRequest();
+
+    $this->assertInstanceOf('Facebook\Entities\FacebookRequest', $nextPage);
+    $this->assertInstanceOf('Facebook\Entities\FacebookRequest', $prevPage);
+    $this->assertNotSame($this->request, $nextPage);
+    $this->assertNotSame($this->request, $prevPage);
+    $this->assertEquals('/v1337/1234567890/likes?access_token=foo_token&after=bar_after_cursor&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&foo=bar&keep=me', $nextPage->getUrl());
+    $this->assertEquals('/v1337/1234567890/likes?access_token=foo_token&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&before=bar_before_cursor&foo=bar&keep=me', $prevPage->getUrl());
+  }
+
+}

--- a/tests/Url/FacebookUrlManipulatorTest.php
+++ b/tests/Url/FacebookUrlManipulatorTest.php
@@ -91,4 +91,129 @@ class FacebookUrlManipulatorTest extends \PHPUnit_Framework_TestCase
     ];
   }
 
+  public function testGracefullyHandlesUrlAppending()
+  {
+    $params = [];
+    $url = 'https://www.foo.com/';
+    $processed_url = FacebookUrlManipulator::appendParamsToUrl($url, $params);
+    $this->assertEquals('https://www.foo.com/', $processed_url);
+
+    $params = [
+      'access_token' => 'foo',
+    ];
+    $url = 'https://www.foo.com/';
+    $processed_url = FacebookUrlManipulator::appendParamsToUrl($url, $params);
+    $this->assertEquals('https://www.foo.com/?access_token=foo', $processed_url);
+
+    $params = [
+      'access_token' => 'foo',
+      'bar' => 'baz',
+    ];
+    $url = 'https://www.foo.com/?foo=bar';
+    $processed_url = FacebookUrlManipulator::appendParamsToUrl($url, $params);
+    $this->assertEquals('https://www.foo.com/?access_token=foo&bar=baz&foo=bar', $processed_url);
+
+    $params = [
+      'access_token' => 'foo',
+    ];
+    $url = 'https://www.foo.com/?foo=bar&access_token=bar';
+    $processed_url = FacebookUrlManipulator::appendParamsToUrl($url, $params);
+    $this->assertEquals('https://www.foo.com/?access_token=bar&foo=bar', $processed_url);
+  }
+
+  public function testSlashesAreProperlyPrepended()
+  {
+    $slashTestOne = FacebookUrlManipulator::forceSlashPrefix('foo');
+    $slashTestTwo = FacebookUrlManipulator::forceSlashPrefix('/foo');
+    $slashTestThree = FacebookUrlManipulator::forceSlashPrefix('foo/bar');
+    $slashTestFour = FacebookUrlManipulator::forceSlashPrefix('/foo/bar');
+    $slashTestFive = FacebookUrlManipulator::forceSlashPrefix(null);
+    $slashTestSix = FacebookUrlManipulator::forceSlashPrefix('');
+
+    $this->assertEquals('/foo', $slashTestOne);
+    $this->assertEquals('/foo', $slashTestTwo);
+    $this->assertEquals('/foo/bar', $slashTestThree);
+    $this->assertEquals('/foo/bar', $slashTestFour);
+    $this->assertEquals(null, $slashTestFive);
+    $this->assertEquals('', $slashTestSix);
+  }
+
+  public function testParamsCanBeReturnedAsArray()
+  {
+    $paramsOne = FacebookUrlManipulator::getParamsAsArray('/foo');
+    $paramsTwo = FacebookUrlManipulator::getParamsAsArray('/foo?one=1&two=2');
+    $paramsThree = FacebookUrlManipulator::getParamsAsArray('https://www.foo.com');
+    $paramsFour = FacebookUrlManipulator::getParamsAsArray('https://www.foo.com/?');
+    $paramsFive = FacebookUrlManipulator::getParamsAsArray('https://www.foo.com/?foo=bar');
+
+    $this->assertEquals([], $paramsOne);
+    $this->assertEquals(['one' => '1', 'two' => '2'], $paramsTwo);
+    $this->assertEquals([], $paramsThree);
+    $this->assertEquals([], $paramsFour);
+    $this->assertEquals(['foo' => 'bar'], $paramsFive);
+  }
+
+  /**
+   * @dataProvider provideMergableEndpoints
+   */
+  public function testParamsCanBeMergedOntoUrlProperly($urlOne, $urlTwo, $expected)
+  {
+    $result = FacebookUrlManipulator::mergeUrlParams($urlOne, $urlTwo);
+
+    $this->assertEquals($result, $expected);
+  }
+
+  public function provideMergableEndpoints()
+  {
+    return [
+      [
+        'https://www.foo.com/?foo=ignore_foo&dance=fun',
+        '/me?foo=keep_foo',
+        '/me?dance=fun&foo=keep_foo',
+      ],
+      [
+        'https://www.bar.com?',
+        'https://foo.com?foo=bar',
+        'https://foo.com?foo=bar',
+      ],
+      [
+        'you',
+        'me',
+        'me',
+      ],
+      [
+        '/1234?swing=fun',
+        '/1337?bar=baz&west=coast',
+        '/1337?bar=baz&swing=fun&west=coast',
+      ],
+    ];
+  }
+
+  public function testGraphUrlsCanBeTrimmed()
+  {
+    $fullGraphUrl = 'https://graph.facebook.com/';
+    $baseGraphUrl = FacebookUrlManipulator::baseGraphUrlEndpoint($fullGraphUrl);
+    $this->assertEquals('/', $baseGraphUrl);
+
+    $fullGraphUrl = 'https://graph.facebook.com/v1.0/';
+    $baseGraphUrl = FacebookUrlManipulator::baseGraphUrlEndpoint($fullGraphUrl);
+    $this->assertEquals('/', $baseGraphUrl);
+
+    $fullGraphUrl = 'https://graph.facebook.com/me';
+    $baseGraphUrl = FacebookUrlManipulator::baseGraphUrlEndpoint($fullGraphUrl);
+    $this->assertEquals('/me', $baseGraphUrl);
+
+    $fullGraphUrl = 'https://graph.beta.facebook.com/me';
+    $baseGraphUrl = FacebookUrlManipulator::baseGraphUrlEndpoint($fullGraphUrl);
+    $this->assertEquals('/me', $baseGraphUrl);
+
+    $fullGraphUrl = 'https://whatever-they-want.facebook.com/v2.1/me';
+    $baseGraphUrl = FacebookUrlManipulator::baseGraphUrlEndpoint($fullGraphUrl);
+    $this->assertEquals('/me', $baseGraphUrl);
+
+    $fullGraphUrl = 'https://graph.facebook.com/v5.301/1233?foo=bar';
+    $baseGraphUrl = FacebookUrlManipulator::baseGraphUrlEndpoint($fullGraphUrl);
+    $this->assertEquals('/1233?foo=bar', $baseGraphUrl);
+  }
+
 }


### PR DESCRIPTION
I had to refactor the request/response logic slightly to get this to work. But pagination is super-smart now.

When you hit the `/me/photos` endpoint, you might get a response like this:

``` json
{
  "data": [
  ], 
  "paging": {
    "cursors": {
      "before": "TRvek9UUXdPRGdsfsdEYzRNelk9", 
      "after": "TVRTlRvek9UUXsdfdsfBMk5EYzRNelk9"
    }, 
    "next": "https://graph.facebook.com/v2.2/1234/photos?pretty=0&after=TVRTlRvek9UUXsdfdsfBMk5EYzRNelk9"
  }
}
```

It's easy to just grab the `$.paging.next` value, slap on the access token and app secret proof and you've got the next page results. And with the help of `Facebook\Facebook`, you can paginate like so:

``` php
$listOfPhotos = $response->getGraphList();

// Get the next page of results
$nextPageOfPhotos = $fb->next($listOfPhotos);
// Or the previous page of results
$previousPageOfPhotos = $fb->previous($listOfPhotos);
```

But what about then you get deeply-embedded pagination data with just the cursors and no URL?

``` json
{
  "data": [
    {
      "source": "https://scontent-a.xx.fbcdn.net/foo.jpg", 
      "likes": {
        "data": [
          . . .
        ], 
        "paging": {
          "cursors": {
            "before": "NTcwODIzNDE2Mzc3OTU0", 
            "after": "MTAxNTI0NDAwODEzNjU1MjI="
          }
        }
      }, 
    },
    . . .
  ]
}
```

How do you paginate over the likes? `GraphList` to the rescue! You do it just like you would on the root list:

``` php
$listOfPhotos = $response->getGraphList();

// Get the next page of likes for first photo
$nextPageOfLikes = $fb->next($listOfPhotos[0]['likes']);
```

Full example:

``` php
$listOfPages = $response->getGraphList();
// Only grab 5 pages
$maxPages = 5;
$pageCount = 0;

do {
  echo '<h1>Page #' . $page_count . ':</h1>' . "\n\n";

  foreach ($listOfPages as $page) {
    var_dump($page->asArray());

    $likes = $page['likes'];
    do {
      echo '<p>Likes:</p>' . "\n\n";
      var_dump($likes->asArray());
    } while ($likes = $fb->next($likes));
  }
  $pageCount++;
} while ($pageCount < $maxPages && $listOfPages = $fb->next($listOfPages));
```

I added [some documentation](https://github.com/SammyK/facebook-php-sdk-v4/blob/add-pagination/docs/GraphList.fbmd) but it could be expanded on.

I've got another PR ready after this one that adds native [file upload functionality](https://github.com/SammyK/facebook-php-sdk-v4/tree/native-file-upload-support) to both regular and batch requests. Turns out, file uploads have been broken this whole time. Lol. :)
