### PR TITLE
[4.1] Added injectable CSPRSG

### DIFF
--- a/docs/Facebook.fbmd
+++ b/docs/Facebook.fbmd
@@ -56,6 +56,7 @@ $fb = new Facebook\Facebook([
   'http_client_handler' => 'guzzle',
   'persistent_data_handler' => 'memory',
   'url_detection_handler' => new MyUrlDetectionHandler(),
+  'pseudo_random_string_generator' => new MyPseudoRandomStringGenerator(),
 ]);
 ~~~~
 
@@ -114,6 +115,29 @@ The SDK will do its best to detect the proper current URL but this can sometimes
 ~~~~
 $fb = new Facebook([
   'url_detection_handler' => new MyUrlDetectionHandler(),
+]);
+~~~~
+
+If any other value is provided an `InvalidArgumentException` will be thrown.
+
+### `pseudo_random_string_generator`
+Allows you to overwrite the default cryptographically secure pseudo-random string generator.
+
+Generating random strings in PHP is easy but generating _cryptographically secure_ random strings is another matter. By default the SDK will attempt to detect a suitable to cryptographically secure random string generator for you. If a cryptographically secure method cannot be detected, a `Facebook\Exceptions\FacebookSDKException` will be thrown.
+
+You can force a specific implementation of the CSPRSG's provided in the SDK by setting `pseudo_random_string_generator` to one of the following methods: `mcrypt`, `openssl` and `urandom`.
+
+~~~~
+$fb = new Facebook([
+  'pseudo_random_string_generator' => 'openssl',
+]);
+~~~~
+
+You can write your own CSPRSG that implements the `[Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface](/docs/php/PseudoRandomStringGeneratorInterface)` and set the value of `pseudo_random_string_generator` to an instance of your custom generator.
+
+~~~~
+$fb = new Facebook([
+  'pseudo_random_string_generator' => new MyPseudoRandomStringGenerator(),
 ]);
 ~~~~
 

--- a/docs/PseudoRandomStringGeneratorInterface.fbmd
+++ b/docs/PseudoRandomStringGeneratorInterface.fbmd
@@ -1,0 +1,65 @@
+<card>
+# The cryptographically secure pseudo-random string generator interface for the Facebook SDK for PHP
+
+The cryptographically secure pseudo-random string generator interface allows you to overwrite the default CSPRSG logic by coding to the `Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface`.
+</card>
+
+<card>
+## Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface {#overview}
+
+By default the SDK will attempt to generate a cryptographically secure random string using a number of methods. If a cryptographically secure method is not detected, a `Facebook\Exceptions\FacebookSDKException` will be thrown.
+
+If your hosting environment does not support any of the CSPRSG methods used by the SDK or if you have preferred CSPRSG, you can provide your own CSPRSG to the SDK using this interface.
+
+> **Caution:** Although it is popular to use `rand()`, `mt_rand()` and `uniqid()` to generate random strings in PHP, these methods are not cryptographically secure. Since the pseudo-random string generator is used to validate against Cross-Site Request Forgery (CSRF) attacks, the random strings _must_ be cryptographically secure. Only overwrite this functionality if your custom pseudo-random string generator is a cryptographically strong one.
+
+An example of implementing a custom CSPRSG:
+
+~~~~
+use Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface;
+
+class MyCustomPseudoRandomStringGenerator implements PseudoRandomStringGeneratorInterface
+{
+  /**
+   * @inheritdoc
+   */
+  public function getPseudoRandomString($length)
+  {
+    $randomString = '';
+
+    // . . . Do CSPRSG logic here . . .
+
+    return $randomString;
+  }
+}
+~~~~
+
+To enable your custom CSPRSG implementation in the SDK, you can set an instance of the generator to the `pseudo_random_string_generator` config of the `Facebook\Facebook` super service.
+
+~~~~
+$fb = new Facebook\Facebook([
+  // . . .
+  'pseudo_random_string_generator' => new MyCustomPseudoRandomStringGenerator(),
+  // . . .
+  ]);
+~~~~
+
+Alternatively, if you're working with the `Facebook\Helpers\FacebookRedirectLoginHelper` directly, you can inject your custom generator via the constructor.
+
+~~~~
+use Facebook\Helpers\FacebookRedirectLoginHelper;
+
+$myPseudoRandomStringGenerator = new MyCustomPseudoRandomStringGenerator();
+$helper = new FacebookRedirectLoginHelper($fbApp, null, null, $myPseudoRandomStringGenerator);
+~~~~
+</card>
+
+<card>
+## Method Reference {#method-reference}
+
+### getPseudoRandomString() {#get-pseudo-random-string}
+~~~~
+public string getPseudoRandomString(int $length)
+~~~~
+Returns a cryptographically secure pseudo-random string that is `$length` characters long.
+</card>

--- a/docs/sdk_reference.fbmd
+++ b/docs/sdk_reference.fbmd
@@ -223,7 +223,7 @@ FB(devsite:markdown-wiki:table {
 <card>
 # Interfaces {#interfaces}
 
-Interfaces you can code to.
+You can overwrite certain functionality of the SDK by coding to an interface.
 
 FB(devsite:markdown-wiki:table {
   columns: ['Interface name','Description',],
@@ -239,6 +239,10 @@ FB(devsite:markdown-wiki:table {
     [
       '`[Facebook\Url\UrlDetectionInterface](/docs/php/UrlDetectionInterface)`',
       'Interface to code your own URL detection logic.',
+    ],
+    [
+      '`[Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface](/docs/php/PseudoRandomStringGeneratorInterface)`',
+      'Interface to code your own cryptographically secure pseudo-random string generator.',
     ],
   ],
 })

--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -34,6 +34,10 @@ use Facebook\FileUpload\FacebookVideo;
 use Facebook\GraphNodes\GraphList;
 use Facebook\Url\UrlDetectionInterface;
 use Facebook\Url\FacebookUrlDetectionHandler;
+use Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface;
+use Facebook\PseudoRandomString\McryptPseudoRandomStringGenerator;
+use Facebook\PseudoRandomString\OpenSslPseudoRandomStringGenerator;
+use Facebook\PseudoRandomString\UrandomPseudoRandomStringGenerator;
 use Facebook\HttpClients\FacebookHttpClientInterface;
 use Facebook\HttpClients\FacebookCurlHttpClient;
 use Facebook\HttpClients\FacebookStreamHttpClient;
@@ -91,6 +95,12 @@ class Facebook
   protected $urlDetectionHandler;
 
   /**
+   * @var PseudoRandomStringGeneratorInterface|null The cryptographically secure
+   *                                                pseudo-random string generator.
+   */
+  protected $pseudoRandomStringGenerator;
+
+  /**
    * @var AccessToken|null The default access token to use with requests.
    */
   protected $defaultAccessToken;
@@ -109,13 +119,6 @@ class Facebook
    * @var FacebookResponse|FacebookBatchResponse|null Stores the last request made to Graph.
    */
   protected $lastResponse;
-
-  /**
-   * @TODO Add FacebookInputInterface
-   * @TODO Add FacebookRandomGeneratorInterface
-   * @TODO Add FacebookRequestInterface
-   * @TODO Add FacebookResponseInterface
-   */
 
   /**
    * Instantiates a new Facebook super-class object.
@@ -175,6 +178,22 @@ class Facebook
         throw new \InvalidArgumentException(
           'The url_detection_handler must be an instance of Facebook\Url\UrlDetectionInterface'
           );
+      }
+    }
+
+    if (isset($config['pseudo_random_string_generator'])) {
+      if ($config['pseudo_random_string_generator'] instanceof PseudoRandomStringGeneratorInterface) {
+        $this->pseudoRandomStringGenerator = $config['pseudo_random_string_generator'];
+      } elseif ($config['pseudo_random_string_generator'] === 'mcrypt') {
+        $this->pseudoRandomStringGenerator = new McryptPseudoRandomStringGenerator();
+      } elseif ($config['pseudo_random_string_generator'] === 'openssl') {
+        $this->pseudoRandomStringGenerator = new OpenSslPseudoRandomStringGenerator();
+      } elseif ($config['pseudo_random_string_generator'] === 'urandom') {
+        $this->pseudoRandomStringGenerator = new UrandomPseudoRandomStringGenerator();
+      } else {
+        throw new \InvalidArgumentException(
+          'The pseudo_random_string_generator must be an instance of Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface'
+        );
       }
     }
 
@@ -283,7 +302,8 @@ class Facebook
     return new FacebookRedirectLoginHelper(
       $this->app,
       $this->persistentDataHandler,
-      $this->urlDetectionHandler
+      $this->urlDetectionHandler,
+      $this->pseudoRandomStringGenerator
     );
   }
 

--- a/src/Facebook/PseudoRandomString/McryptPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/McryptPseudoRandomStringGenerator.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\PseudoRandomString;
+
+use Facebook\Exceptions\FacebookSDKException;
+
+class McryptPseudoRandomStringGenerator implements PseudoRandomStringGeneratorInterface
+{
+
+  use PseudoRandomStringGeneratorTrait;
+
+  /**
+   * @const string The error message when generating the string fails.
+   */
+  const ERROR_MESSAGE = 'Unable to generate a cryptographically secure pseudo-random string from mcrypt_create_iv(). ';
+
+  /**
+   * @throws FacebookSDKException
+   */
+  public function __construct()
+  {
+    if ( ! function_exists('mcrypt_create_iv')) {
+      throw new FacebookSDKException(
+        static::ERROR_MESSAGE .
+        'The function mcrypt_create_iv() does not exist.'
+      );
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getPseudoRandomString($length)
+  {
+    $this->validateLength($length);
+
+    $binaryString = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
+
+    if ($binaryString === false) {
+      throw new FacebookSDKException(
+        static::ERROR_MESSAGE .
+        'mcrypt_create_iv() returned an error.'
+      );
+    }
+
+    return $this->binToHex($binaryString, $length);
+  }
+
+}

--- a/src/Facebook/PseudoRandomString/OpenSslPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/OpenSslPseudoRandomStringGenerator.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\PseudoRandomString;
+
+use Facebook\Exceptions\FacebookSDKException;
+
+class OpenSslPseudoRandomStringGenerator implements PseudoRandomStringGeneratorInterface
+{
+
+  use PseudoRandomStringGeneratorTrait;
+
+  /**
+   * @const string The error message when generating the string fails.
+   */
+  const ERROR_MESSAGE = 'Unable to generate a cryptographically secure pseudo-random string from openssl_random_pseudo_bytes(). ';
+
+  /**
+   * @throws FacebookSDKException
+   */
+  public function __construct()
+  {
+    if ( ! function_exists('openssl_random_pseudo_bytes')) {
+      throw new FacebookSDKException(
+        static::ERROR_MESSAGE .
+        'The function openssl_random_pseudo_bytes() does not exist.'
+      );
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getPseudoRandomString($length)
+  {
+    $this->validateLength($length);
+
+    $wasCryptographicallyStrong = false;
+    $binaryString = openssl_random_pseudo_bytes($length, $wasCryptographicallyStrong);
+
+    if ($binaryString === false) {
+      throw new FacebookSDKException(
+        static::ERROR_MESSAGE .
+        'openssl_random_pseudo_bytes() returned an unknown error.'
+      );
+    }
+
+    if ($wasCryptographicallyStrong !== true) {
+      throw new FacebookSDKException(
+        static::ERROR_MESSAGE .
+        'openssl_random_pseudo_bytes() returned a pseudo-random string but ' .
+        'it was not cryptographically secure and cannot be used.'
+      );
+    }
+
+    return $this->binToHex($binaryString, $length);
+  }
+
+}

--- a/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorInterface.php
+++ b/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorInterface.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\PseudoRandomString;
+
+/**
+ * Interface
+ * @package Facebook
+ */
+interface PseudoRandomStringGeneratorInterface
+{
+
+  /**
+   * Get a cryptographically secure pseudo-random string of arbitrary length.
+   *
+   * @see http://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/
+   *
+   * @param int $length The length of the string to return.
+   *
+   * @return string
+   *
+   * @throws \Facebook\Exceptions\FacebookSDKException|\InvalidArgumentException
+   */
+  public function getPseudoRandomString($length);
+
+}

--- a/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorTrait.php
+++ b/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorTrait.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\PseudoRandomString;
+
+trait PseudoRandomStringGeneratorTrait
+{
+
+  /**
+   * Validates the length argument of a random string.
+   *
+   * @param int $length The length to validate.
+   *
+   * @throws \InvalidArgumentException
+   */
+  public function validateLength($length)
+  {
+    if ( ! is_int($length)) {
+      throw new \InvalidArgumentException(
+        'getPseudoRandomString() expects an integer for the string length'
+      );
+    }
+
+    if ($length < 1) {
+      throw new \InvalidArgumentException(
+        'getPseudoRandomString() expects a length greater than 1'
+      );
+    }
+  }
+
+  /**
+   * Converts binary data to hexadecimal of arbitrary length.
+   *
+   * @param string $binaryData The binary data to convert to hex.
+   * @param int $length The length of the string to return.
+   *
+   * @return string
+   */
+  public function binToHex($binaryData, $length)
+  {
+    return mb_substr(bin2hex($binaryData), 0, $length);
+  }
+
+}

--- a/src/Facebook/PseudoRandomString/UrandomPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/UrandomPseudoRandomStringGenerator.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\PseudoRandomString;
+
+use Facebook\Exceptions\FacebookSDKException;
+
+class UrandomPseudoRandomStringGenerator implements PseudoRandomStringGeneratorInterface
+{
+
+  use PseudoRandomStringGeneratorTrait;
+
+  /**
+   * @const string The error message when generating the string fails.
+   */
+  const ERROR_MESSAGE = 'Unable to generate a cryptographically secure pseudo-random string from /dev/urandom. ';
+
+  /**
+   * @throws FacebookSDKException
+   */
+  public function __construct()
+  {
+    if (ini_get('open_basedir')) {
+      throw new FacebookSDKException(
+        static::ERROR_MESSAGE .
+        'There is an open_basedir constraint that prevents access to /dev/urandom.'
+      );
+    }
+
+    if ( ! is_readable('/dev/urandom')) {
+      throw new FacebookSDKException(
+        static::ERROR_MESSAGE .
+        'Unable to read from /dev/urandom.'
+      );
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getPseudoRandomString($length)
+  {
+    $this->validateLength($length);
+
+    $stream = fopen('/dev/urandom', 'rb');
+    if ( ! is_resource($stream)) {
+      throw new FacebookSDKException(
+        static::ERROR_MESSAGE .
+        'Unable to open stream to /dev/urandom.'
+      );
+    }
+
+    $binaryString = fread($stream, $length);
+    fclose($stream);
+
+    if( ! $binaryString) {
+      throw new FacebookSDKException(
+        static::ERROR_MESSAGE .
+        'Stream to /dev/urandom returned no data.'
+      );
+    }
+
+    return $this->binToHex($binaryString, $length);
+  }
+
+}

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -29,6 +29,7 @@ use Facebook\Http\GraphRawResponse;
 use Facebook\HttpClients\FacebookHttpClientInterface;
 use Facebook\PersistentData\PersistentDataInterface;
 use Facebook\Url\UrlDetectionInterface;
+use Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface;
 use Facebook\Entities\FacebookRequest;
 use Facebook\GraphNodes\GraphList;
 
@@ -51,6 +52,13 @@ class FooPersistentDataInterface implements PersistentDataInterface
 class FooUrlDetectionInterface implements UrlDetectionInterface
 {
   public function getCurrentUrl() { return 'https://foo.bar'; }
+}
+
+class FooBarPseudoRandomStringGenerator implements PseudoRandomStringGeneratorInterface
+{
+  public function getPseudoRandomString($length) {
+    return 'csprs123';
+  }
 }
 
 class FacebookTest extends \PHPUnit_Framework_TestCase
@@ -165,6 +173,74 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
   /**
    * @expectedException \InvalidArgumentException
    */
+  public function testSettingAnInvalidPseudoRandomStringGeneratorThrows()
+  {
+    $config = array_merge($this->config, [
+        'pseudo_random_string_generator' => 'foo_generator',
+      ]);
+    new Facebook($config);
+  }
+
+  public function testMcryptCsprgCanBeForced()
+  {
+    if ( ! function_exists('mcrypt_create_iv')) {
+      $this->markTestSkipped(
+        'Mcrypt must be installed to test mcrypt_create_iv().'
+      );
+    }
+
+    $config = array_merge($this->config, [
+        'persistent_data_handler' => 'memory', // To keep session errors from happening
+        'pseudo_random_string_generator' => 'mcrypt'
+      ]);
+    $fb = new Facebook($config);
+    $this->assertInstanceOf('Facebook\PseudoRandomString\McryptPseudoRandomStringGenerator',
+      $fb->getRedirectLoginHelper()->getPseudoRandomStringGenerator());
+  }
+
+  public function testOpenSslCsprgCanBeForced()
+  {
+    if ( ! function_exists('openssl_random_pseudo_bytes')) {
+      $this->markTestSkipped(
+        'The OpenSSL extension must be enabled to test openssl_random_pseudo_bytes().'
+      );
+    }
+
+    $config = array_merge($this->config, [
+        'persistent_data_handler' => 'memory', // To keep session errors from happening
+        'pseudo_random_string_generator' => 'openssl'
+      ]);
+    $fb = new Facebook($config);
+    $this->assertInstanceOf('Facebook\PseudoRandomString\OpenSslPseudoRandomStringGenerator',
+      $fb->getRedirectLoginHelper()->getPseudoRandomStringGenerator());
+  }
+
+  public function testUrandomCsprgCanBeForced()
+  {
+    if (ini_get('open_basedir')) {
+      $this->markTestSkipped(
+        'Cannot test /dev/urandom generator due to open_basedir constraint.'
+      );
+    }
+
+    if ( ! is_readable('/dev/urandom')) {
+      $this->markTestSkipped(
+        '/dev/urandom not found or is not readable.'
+      );
+    }
+    
+    $config = array_merge($this->config, [
+        'persistent_data_handler' => 'memory', // To keep session errors from happening
+        'pseudo_random_string_generator' => 'urandom'
+      ]);
+    $fb = new Facebook($config);
+    $this->assertInstanceOf('Facebook\PseudoRandomString\UrandomPseudoRandomStringGenerator',
+      $fb->getRedirectLoginHelper()->getPseudoRandomStringGenerator());
+  }
+
+  /**
+   * @expectedException \InvalidArgumentException
+   */
   public function testSettingAnAccessThatIsNotStringOrAccessTokenThrows()
   {
     $config = array_merge($this->config, [
@@ -177,27 +253,38 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
   {
     $config = array_merge($this->config, [
         'default_access_token' => 'foo_token',
-        'http_client_handler' => new FooClientInterface(),
-        'persistent_data_handler' => new FooPersistentDataInterface(),
-        'url_detection_handler' => new FooUrlDetectionInterface(),
         'enable_beta_mode' => true,
         'default_graph_version' => 'v1337',
       ]);
     $fb = new Facebook($config);
 
     $request = $fb->request('FOO_VERB', '/foo');
+    $this->assertEquals('1337', $request->getApp()->getId());
+    $this->assertEquals('foo_secret', $request->getApp()->getSecret());
+    $this->assertEquals('foo_token', (string) $request->getAccessToken());
+    $this->assertEquals('v1337', $request->getGraphVersion());
+    $this->assertEquals(FacebookClient::BASE_GRAPH_URL_BETA,
+      $fb->getClient()->getBaseGraphUrl());
+  }
+
+  public function testCanInjectCustomHandlers()
+  {
+    $config = array_merge($this->config, [
+        'http_client_handler' => new FooClientInterface(),
+        'persistent_data_handler' => new FooPersistentDataInterface(),
+        'url_detection_handler' => new FooUrlDetectionInterface(),
+        'pseudo_random_string_generator' => new FooBarPseudoRandomStringGenerator(),
+      ]);
+    $fb = new Facebook($config);
+
     $this->assertInstanceOf('Facebook\Tests\FooClientInterface',
       $fb->getClient()->getHttpClientHandler());
     $this->assertInstanceOf('Facebook\Tests\FooPersistentDataInterface',
       $fb->getRedirectLoginHelper()->getPersistentDataHandler());
     $this->assertInstanceOf('Facebook\Tests\FooUrlDetectionInterface',
       $fb->getRedirectLoginHelper()->getUrlDetectionHandler());
-    $this->assertEquals(FacebookClient::BASE_GRAPH_URL_BETA,
-      $fb->getClient()->getBaseGraphUrl());
-    $this->assertEquals('1337', $request->getApp()->getId());
-    $this->assertEquals('foo_secret', $request->getApp()->getSecret());
-    $this->assertEquals('foo_token', (string) $request->getAccessToken());
-    $this->assertEquals('v1337', $request->getGraphVersion());
+    $this->assertInstanceOf('Facebook\Tests\FooBarPseudoRandomStringGenerator',
+      $fb->getRedirectLoginHelper()->getPseudoRandomStringGenerator());
   }
 
   public function testPaginationReturnsProperResponse()

--- a/tests/PseudoRandomString/McryptPseudoRandomStringGeneratorTest.php
+++ b/tests/PseudoRandomString/McryptPseudoRandomStringGeneratorTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\PseudoRandomString;
+
+use Facebook\PseudoRandomString\McryptPseudoRandomStringGenerator;
+
+class McryptPseudoRandomStringGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+
+  public function testCanGenerateRandomStringOfArbitraryLength()
+  {
+    if ( ! function_exists('mcrypt_create_iv')) {
+      $this->markTestSkipped(
+        'Mcrypt must be installed to test mcrypt_create_iv().'
+      );
+    }
+
+    $prsg = new McryptPseudoRandomStringGenerator();
+    $randomString = $prsg->getPseudoRandomString(10);
+
+    $this->assertEquals(1, preg_match('/^([0-9a-f]+)$/', $randomString));
+    $this->assertEquals(10, mb_strlen($randomString));
+  }
+
+}

--- a/tests/PseudoRandomString/OpenSslPseudoRandomStringGeneratorTest.php
+++ b/tests/PseudoRandomString/OpenSslPseudoRandomStringGeneratorTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\PseudoRandomString;
+
+use Facebook\PseudoRandomString\OpenSslPseudoRandomStringGenerator;
+
+class OpenSslPseudoRandomStringGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+
+  public function testCanGenerateRandomStringOfArbitraryLength()
+  {
+    if ( ! function_exists('openssl_random_pseudo_bytes')) {
+      $this->markTestSkipped(
+        'The OpenSSL extension must be enabled to test openssl_random_pseudo_bytes().'
+      );
+    }
+
+    $prsg = new OpenSslPseudoRandomStringGenerator();
+    $randomString = $prsg->getPseudoRandomString(10);
+
+    $this->assertEquals(1, preg_match('/^([0-9a-f]+)$/', $randomString));
+    $this->assertEquals(10, mb_strlen($randomString));
+  }
+
+}

--- a/tests/PseudoRandomString/PseudoRandomStringGeneratorTraitTest.php
+++ b/tests/PseudoRandomString/PseudoRandomStringGeneratorTraitTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\PseudoRandomString;
+
+use Facebook\PseudoRandomString\PseudoRandomStringGeneratorTrait;
+
+class MyFooBarPseudoRandomStringGenerator
+{
+  use PseudoRandomStringGeneratorTrait;
+}
+
+class PseudoRandomStringGeneratorTraitTest extends \PHPUnit_Framework_TestCase
+{
+
+  /**
+   * @expectedException \InvalidArgumentException
+   */
+  public function testAnInvalidLengthWillThrow()
+  {
+    $prsg = new MyFooBarPseudoRandomStringGenerator();
+    $prsg->validateLength('foo_len');
+  }
+
+  /**
+   * @expectedException \InvalidArgumentException
+   */
+  public function testALengthThatIsNotAtLeastOneCharacterWillThrow()
+  {
+    $prsg = new MyFooBarPseudoRandomStringGenerator();
+    $prsg->validateLength(0);
+  }
+
+}

--- a/tests/PseudoRandomString/UrandomPseudoRandomStringGeneratorTest.php
+++ b/tests/PseudoRandomString/UrandomPseudoRandomStringGeneratorTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\PseudoRandomString;
+
+use Facebook\PseudoRandomString\UrandomPseudoRandomStringGenerator;
+
+class UrandomPseudoRandomStringGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+
+  public function testCanGenerateRandomStringOfArbitraryLength()
+  {
+    if (ini_get('open_basedir')) {
+      $this->markTestSkipped(
+        'Cannot test /dev/urandom generator due to open_basedir constraint.'
+      );
+    }
+
+    if ( ! is_readable('/dev/urandom')) {
+      $this->markTestSkipped(
+        '/dev/urandom not found or is not readable.'
+      );
+    }
+
+    $prsg = new UrandomPseudoRandomStringGenerator();
+    $randomString = $prsg->getPseudoRandomString(10);
+
+    $this->assertEquals(1, preg_match('/^([0-9a-f]+)$/', $randomString));
+    $this->assertEquals(10, mb_strlen($randomString));
+  }
+
+}


### PR DESCRIPTION
Added injectable cryptographically secure pseudo-random string generators and improved on the existing CSPRSG logic.

Complete with [docs](https://github.com/SammyK/facebook-php-sdk-v4/blob/injectable-prsg/docs/PseudoRandomStringGeneratorInterface.fbmd)! :)

This addresses issues from #262 & #128 and crosses off another #136 TODO. :)
