### PR TITLE
[4.1] Added helpers to super service. Added setter for default access token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,34 +16,34 @@ Usage
 Simple GET example of a user's profile.
 
 ```php
-use Facebook\Facebook;
-use Facebook\Exceptions\FacebookResponseException;
-use Facebook\Exceptions\FacebookSDKException;
-
-$fb = new Facebook([
+$fb = new Facebook\Facebook([
   'app_id' => '{app-id}',
   'app_secret' => '{app-secret}',
   //'default_access_token' => '{access-token}', // optional
 ]);
 
 // Use one of the helper classes to get a Facebook\Entities\AccessToken entity.
-//   Facebook\Helpers\FacebookRedirectLoginHelper
-//   Facebook\Helpers\FacebookJavaScriptLoginHelper
-//   Facebook\Helpers\FacebookCanvasLoginHelper
-//   Facebook\Helpers\FacebookPageTabHelper
+//   $helper = $fb->getRedirectLoginHelper();
+//   $helper = $fb->getJavaScriptHelper();
+//   $helper = $fb->getCanvasHelper();
+//   $helper = $fb->getPageTabHelper();
 
 try {
-  // Get the Facebook\GraphNodes\GraphUser object for the current user:
+  // Get the Facebook\GraphNodes\GraphUser object for the current user.
+  // If you provided a 'default_access_token', the '{access-token}' is optional.
   $response = $fb->get('/me', '{access-token}');
-  $me = $response->getGraphUser();
-  echo 'Logged in as ' . $me->getName();
-} catch(FacebookResponseException $e) {
+} catch(Facebook\Exceptions\FacebookResponseException $e) {
   // When Graph returns an error
   echo 'Graph returned an error: ' . $e->getMessage();
-} catch(FacebookSDKException $e) {
+  exit;
+} catch(Facebook\Exceptions\FacebookSDKException $e) {
   // When validation fails or other local issues
   echo 'Facebook SDK returned an error: ' . $e->getMessage();
+  exit;
 }
+
+$me = $response->getGraphUser();
+echo 'Logged in as ' . $me->getName();
 ```
 
 Complete documentation, installation instructions, and examples are available at:

--- a/docs/Facebook.fbmd
+++ b/docs/Facebook.fbmd
@@ -161,9 +161,30 @@ Returns the last response received from the Graph API in the form of a `Facebook
 <card>
 ### getDefaultAccessToken() {#get-default-access-token}
 ~~~~
-public AccessToken|null getDefaultAccessToken()
+public Facebook\Entities\AccessToken|null getDefaultAccessToken()
 ~~~~
-Returns the default `Facebook\Entities\AccessToken` entity if the configuration option `default_access_token` was set.
+
+Returns the default fallback `Facebook\Entities\AccessToken` entity that is being used with every request to Graph. This value can be set with the configuration option `default_access_token` or by using `setDefaultAccessToken()`.
+</card>
+
+<card>
+### setDefaultAccessToken() {#set-default-access-token}
+~~~~
+public setDefaultAccessToken(string|Facebook\Entities\AccessToken $accessToken)
+~~~~
+
+Sets the default access token to be use with all requests sent to Graph. The access token can be in string or `Facebook\Entities\AccessToken` format.
+
+~~~~
+$fb->setDefaultAccessToken('{my-access-token}');
+
+// . . . OR . . .
+
+$accessToken = new Facebook\Entities\AccessToken('{my-access-token}');
+$fb->setDefaultAccessToken($accessToken);
+~~~~
+
+This setting will overwrite the value from `default_access_token` if it was passed to the `Facebook\Facebook` constructor.
 </card>
 
 <card>
@@ -312,6 +333,45 @@ Returns a [`Facebook\Helpers\FacebookRedirectLoginHelper`](/docs/php/FacebookRed
 
 ~~~~
 $helper = $fb->getRedirectLoginHelper();
+~~~~
+</card>
+
+<card>
+### getJavaScriptHelper() {#get-javascript-helper}
+~~~~
+public Facebook\Helpers\FacebookJavaScriptHelper getJavaScriptHelper()
+~~~~
+
+Returns a [`Facebook\Helpers\FacebookJavaScriptHelper`](/docs/php/FacebookJavaScriptHelper) which is used to access the signed request stored in the cookie set by the JavaScript SDK.
+
+~~~~
+$helper = $fb->getJavaScriptHelper();
+~~~~
+</card>
+
+<card>
+### getCanvasHelper() {#get-canvas-helper}
+~~~~
+public Facebook\Helpers\FacebookCanvasHelper getCanvasHelper()
+~~~~
+
+Returns a [`Facebook\Helpers\FacebookCanvasHelper`](/docs/php/FacebookCanvasHelper) which is used to access the signed request that is `POST`ed to canvas apps.
+
+~~~~
+$helper = $fb->getCanvasHelper();
+~~~~
+</card>
+
+<card>
+### getPageTabHelper() {#get-page-tab-helper}
+~~~~
+public Facebook\Helpers\FacebookPageTabHelper getPageTabHelper()
+~~~~
+
+Returns a [`Facebook\Helpers\FacebookPageTabHelper`](/docs/php/FacebookPageTabHelper) which is used to access the signed request that is `POST`ed to canvas apps and provides a number of helper methods useful for apps living in a page tab context.
+
+~~~~
+$helper = $fb->getPageTabHelper();
 ~~~~
 </card>
 

--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -41,14 +41,15 @@ use Facebook\HttpClients\FacebookGuzzleHttpClient;
 use Facebook\PersistentData\PersistentDataInterface;
 use Facebook\PersistentData\FacebookSessionPersistentDataHandler;
 use Facebook\PersistentData\FacebookMemoryPersistentDataHandler;
+use Facebook\Helpers\FacebookCanvasHelper;
+use Facebook\Helpers\FacebookJavaScriptHelper;
+use Facebook\Helpers\FacebookPageTabHelper;
 use Facebook\Helpers\FacebookRedirectLoginHelper;
 use Facebook\Exceptions\FacebookSDKException;
 
 /**
  * Class Facebook
  * @package Facebook
- *
- * @TODO Add helpers to superclass
  */
 class Facebook
 {
@@ -194,14 +195,7 @@ class Facebook
     }
 
     if (isset($config['default_access_token'])) {
-      if (is_string($config['default_access_token'])) {
-        $this->defaultAccessToken = new AccessToken($config['default_access_token']);
-      } elseif ( ! $config['default_access_token'] instanceof AccessToken) {
-        throw new \InvalidArgumentException(
-          'The "default_access_token" provided must be of type "string"'
-          . ' or Facebook\Entities\AccessToken'
-        );
-      }
+      $this->setDefaultAccessToken($config['default_access_token']);
     }
 
     $this->defaultGraphVersion = isset($config['default_graph_version'])
@@ -264,6 +258,31 @@ class Facebook
   }
 
   /**
+   * Sets the default access token to use with requests.
+   *
+   * @param AccessToken|string $accessToken The access token to save.
+   *
+   * @throws \InvalidArgumentException
+   */
+  public function setDefaultAccessToken($accessToken)
+  {
+    if (is_string($accessToken)) {
+      $this->defaultAccessToken = new AccessToken($accessToken);
+      return;
+    }
+
+    if ($accessToken instanceof AccessToken) {
+      $this->defaultAccessToken = $accessToken;
+      return;
+    }
+
+    throw new \InvalidArgumentException(
+      'The default access token must be of type "string"'
+      . ' or Facebook\Entities\AccessToken'
+    );
+  }
+
+  /**
    * Returns the default Graph version.
    *
    * @return string
@@ -285,6 +304,36 @@ class Facebook
       $this->persistentDataHandler,
       $this->urlDetectionHandler
     );
+  }
+
+  /**
+   * Returns the JavaScript helper.
+   *
+   * @return FacebookJavaScriptHelper
+   */
+  public function getJavaScriptHelper()
+  {
+    return new FacebookJavaScriptHelper($this->app);
+  }
+
+  /**
+   * Returns the canvas helper.
+   *
+   * @return FacebookCanvasHelper
+   */
+  public function getCanvasHelper()
+  {
+    return new FacebookCanvasHelper($this->app);
+  }
+
+  /**
+   * Returns the page tab helper.
+   *
+   * @return FacebookPageTabHelper
+   */
+  public function getPageTabHelper()
+  {
+    return new FacebookPageTabHelper($this->app);
   }
 
   /**

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -30,6 +30,7 @@ use Facebook\HttpClients\FacebookHttpClientInterface;
 use Facebook\PersistentData\PersistentDataInterface;
 use Facebook\Url\UrlDetectionInterface;
 use Facebook\Entities\FacebookRequest;
+use Facebook\Entities\AccessToken;
 use Facebook\GraphNodes\GraphList;
 
 class FooClientInterface implements FacebookHttpClientInterface
@@ -160,6 +161,26 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
   {
     $fb = new Facebook($this->config);
     $this->assertInstanceOf('Facebook\Url\FacebookUrlDetectionHandler', $fb->getUrlDetectionHandler());
+  }
+
+  public function testAnAccessTokenCanBeSetAsAString()
+  {
+    $fb = new Facebook($this->config);
+    $fb->setDefaultAccessToken('foo_token');
+    $accessToken = $fb->getDefaultAccessToken();
+
+    $this->assertInstanceOf('Facebook\Entities\AccessToken', $accessToken);
+    $this->assertEquals('foo_token', (string) $accessToken);
+  }
+
+  public function testAnAccessTokenCanBeSetAsAnAccessTokenEntity()
+  {
+    $fb = new Facebook($this->config);
+    $fb->setDefaultAccessToken(new AccessToken('bar_token'));
+    $accessToken = $fb->getDefaultAccessToken();
+
+    $this->assertInstanceOf('Facebook\Entities\AccessToken', $accessToken);
+    $this->assertEquals('bar_token', (string) $accessToken);
   }
 
   /**


### PR DESCRIPTION
Just a bit more cleanup before really hitting the docs.

Added getters for the rest of the helpers:

``` php
$helper = $fb->getRedirectLoginHelper(); // Already existed
$helper = $fb->getJavaScriptHelper();
$helper = $fb->getCanvasHelper();
$helper = $fb->getPageTabHelper();
```

Added a setter for the default access token. This is handy when you want to use a default access token but don't have it when you instantiate `Facebook\Facebook`.

``` php
$fb = new Facebook\Facebook([ /* */ ]);
// . . . Get access token here . . .
$fb->setDefaultAccessToken($accessToken);
```

Also uncovered a bug that wouldn't set the default access token if you passed in a `Facebook\Entities\AccessToken`. Yikes! Wrote some tests to cover that case. :)
