### PR TITLE
[4.1] Added access to GraphList meta data

### DIFF
--- a/docs/GraphList.fbmd
+++ b/docs/GraphList.fbmd
@@ -69,3 +69,56 @@ do {
 } while ($pageCount < $maxPages && $listOfPages = $fb->next($listOfPages));
 ~~~~
 </card>
+
+<card>
+## Method Reference {#method-reference}
+
+### getMetaData() {#get-meta-data}
+~~~~
+public array getMetaData()
+~~~~
+
+Sometimes Graph will return additional data associated with a list of Graph nodes. You can access this raw data as an array with `getMetaData()`.
+
+~~~~
+$metaData = $graphList->getMetaData();
+~~~~
+
+### getNextCursor() {#get-next-cursor}
+~~~~
+public string|null getNextCursor()
+~~~~
+
+Returns the `$.paging.cursors.after` value if it exists or `null` if it does not exist. Since cursors are sort of like bookmarks for paginating over a list of Graph nodes, it is sometimes handy to store the last cursor used so that you can revisit the exact position at a later time.
+
+~~~~
+$nextCursor = $graphList->getNextCursor();
+// Returns: MMAyDDM5NjA0OTEyMDc0OTM=
+~~~~
+
+### getPreviousCursor() {#get-previous-cursor}
+~~~~
+public string|null getPreviousCursor()
+~~~~
+
+Returns the `$.paging.cursors.before` value if it exists or `null` if it does not exist.
+
+~~~~
+$previousCursor = $graphList->getPreviousCursor();
+// Returns: ODOxMTUzMjQzNTg5zzU5
+~~~~
+
+### getTotalCount() {#get-total-count}
+~~~~
+public int|null getTotalCount()
+~~~~
+
+Some endpoints and edges of Graph support a summary of data. If the `summary=true` modifier was sent with a request on a supported endpoint or edge, Graph will return the total count of results in the meta data under `$.summary.total_count`. `getTotalCount()` will return that value or `null` if it does not exist.
+
+~~~~
+$response = $fb->get('/{post-id}/likes?summary=true');
+$listOfLikes = $response->getGraphList();
+$totalCount = $listOfLikes->getTotalCount();
+// Returns: 10
+~~~~
+</card>

--- a/src/Facebook/GraphNodes/GraphList.php
+++ b/src/Facebook/GraphNodes/GraphList.php
@@ -94,6 +94,50 @@ class GraphList extends Collection
   }
 
   /**
+   * Returns the raw meta data associated with this GraphList.
+   *
+   * @return array
+   */
+  public function getMetaData()
+  {
+    return $this->metaData;
+  }
+
+  /**
+   * Returns the next cursor if it exists.
+   *
+   * @return string|null
+   */
+  public function getNextCursor()
+  {
+    return $this->getCursor('after');
+  }
+
+  /**
+   * Returns the previous cursor if it exists.
+   *
+   * @return string|null
+   */
+  public function getPreviousCursor()
+  {
+    return $this->getCursor('before');
+  }
+
+  /**
+   * Returns the cursor for a specific direction if it exists.
+   *
+   * @param string $direction The direction of the page: after|before
+   *
+   * @return string|null
+   */
+  public function getCursor($direction)
+  {
+    return isset($this->metaData['paging']['cursors'][$direction])
+      ? $this->metaData['paging']['cursors'][$direction]
+      : null;
+  }
+
+  /**
    * Generates a pagination URL based on a cursor.
    *
    * @param string $direction The direction of the page: next|previous
@@ -116,7 +160,8 @@ class GraphList extends Collection
 
     // Do we have a cursor to work with?
     $cursorDirection = $direction === 'next' ? 'after' : 'before';
-    if ( ! isset($this->metaData['paging']['cursors'][$cursorDirection])) {
+    $cursor = $this->getCursor($cursorDirection);
+    if ( ! $cursor) {
       return null;
     }
 
@@ -127,8 +172,6 @@ class GraphList extends Collection
 
     // We have the parent node ID, paging cursor & original request.
     // These were the ingredients chosen to create the perfect little URL.
-    $cursor = $this->metaData['paging']['cursors'][$cursorDirection];
-
     $pageUrl = $this->parentEdgeEndpoint . '?' . $cursorDirection . '=' . urlencode($cursor);
 
     // Pull in the original params
@@ -195,6 +238,19 @@ class GraphList extends Collection
   public function getPreviousPageRequest()
   {
     return $this->getPaginationRequest('previous');
+  }
+
+  /**
+   * The total number of results according to Graph if it exists.
+   * This will be returned if the summary=true modifier is present in the request.
+   *
+   * @return int|null
+   */
+  public function getTotalCount()
+  {
+    return isset($this->metaData['summary']['total_count'])
+      ? $this->metaData['summary']['total_count']
+      : null;
   }
 
 }

--- a/src/Facebook/GraphNodes/GraphObjectFactory.php
+++ b/src/Facebook/GraphNodes/GraphObjectFactory.php
@@ -319,12 +319,9 @@ class GraphObjectFactory
    */
   public function getMetaData(array $data)
   {
-    $meta_data = [];
-    if (isset($data['paging'])) {
-      $meta_data['paging'] = $data['paging'];
-    }
+    unset($data['data']);
 
-    return $meta_data;
+    return $data;
   }
 
   /**


### PR DESCRIPTION
Apparently I'm bored... or it's just PR-Friday and I'm catching PR-fever... :)

As pointed out by Christopher Thomas in a recent [comment on my blog](https://www.sammyk.me/facebook-sdk-v4-for-php-what-you-need-to-know#comment-1722399526), there is some meta data returned by Graph that cannot be accessed by the SDK.

This PR gives direct access to the meta data as well as adds better support for working with cursors when paginating.

It also provides a helper method `GraphList::getTotalCount()` for grabbing the `$.summary.total_count` value when the `summary=true` modifier was sent with a request.

I updated the docs to explain it in more detail. :)
