### PR TITLE
[4.1] Killed "Entities/" folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ As you may have already noticed, the Facebook SDK v4 does not follow strict [sem
   - Moved response collection objects to `GraphNodes\*` directory
   - Moved helpers to `Helpers\*` directory
   - Moved `FacebookRequest` and `FacebookResponse` to `Entities\*` directory
-  - Killed `FacebookSession` in favor of `Facebook\Entities\AccessToken`
+  - Killed `FacebookSession` in favor of `Facebook\AccessToken`
   - Added `FacebookClient` service
   - Renamed `FacebookRequestException` to `FacebookResponseException`
   - Renamed `FacebookHttpable` to `FacebookHttpClientInterface`
@@ -21,7 +21,7 @@ As you may have already noticed, the Facebook SDK v4 does not follow strict [sem
   - Added support for "rerequest" authorization
   - [`AccessToken`] Added serialization support
   - Added `ext-mbstring` to composer require
-  - Added `Facebook\Entities\FacebookApp` entity
+  - Added `Facebook\FacebookApp` entity
   - Namespaced tests
   - Grouped functional tests under `functional` group
   - Added `Facebook\Facebook` super service

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $fb = new Facebook\Facebook([
   //'default_access_token' => '{access-token}', // optional
 ]);
 
-// Use one of the helper classes to get a Facebook\Entities\AccessToken entity.
+// Use one of the helper classes to get a Facebook\AccessToken entity.
 //   $helper = $fb->getRedirectLoginHelper();
 //   $helper = $fb->getJavaScriptHelper();
 //   $helper = $fb->getCanvasHelper();

--- a/docs/Facebook.fbmd
+++ b/docs/Facebook.fbmd
@@ -67,7 +67,7 @@ The ID of your Facebook app (required).
 The secret of your Facebook app (required).
 
 ### `default_access_token`
-The default fallback access token to use if one is not explicitly provided. The value can be of type `string` or `Facebook\Entities\AccessToken`. If any other value is provided an `InvalidArgumentException` will be thrown. Defaults to `null`.
+The default fallback access token to use if one is not explicitly provided. The value can be of type `string` or `Facebook\AccessToken`. If any other value is provided an `InvalidArgumentException` will be thrown. Defaults to `null`.
 
 ### `enable_beta_mode`
 Enable [beta mode](https://developers.facebook.com/docs/support/beta-tier/) so that request are made to the [https://graph.beta.facebook.com](https://graph.beta.facebook.com/) endpoint. Set to boolean `true` to enable or `false` to disable. Defaults to `false`.
@@ -163,7 +163,7 @@ $fb = new Facebook\Facebook();
 ~~~~
 public FacebookApp getApp()
 ~~~~
-Returns the instance of `Facebook\Entities\FacebookApp` for the instantiated service.
+Returns the instance of `Facebook\FacebookApp` for the instantiated service.
 </card>
 
 <card>
@@ -177,34 +177,34 @@ Returns the instance of [`Facebook\FacebookClient`](/docs/php/FacebookClient) fo
 <card>
 ### getLastResponse() {#get-last-response}
 ~~~~
-public Facebook\Entities\FacebookResponse|Facebook\Entities\FacebookBatchResponse|null getLastResponse()
+public Facebook\FacebookResponse|Facebook\FacebookBatchResponse|null getLastResponse()
 ~~~~
-Returns the last response received from the Graph API in the form of a `Facebook\Entities\FacebookResponse` or `Facebook\Entities\FacebookBatchResponse`.
+Returns the last response received from the Graph API in the form of a `Facebook\FacebookResponse` or `Facebook\FacebookBatchResponse`.
 </card>
 
 <card>
 ### getDefaultAccessToken() {#get-default-access-token}
 ~~~~
-public Facebook\Entities\AccessToken|null getDefaultAccessToken()
+public Facebook\AccessToken|null getDefaultAccessToken()
 ~~~~
 
-Returns the default fallback `Facebook\Entities\AccessToken` entity that is being used with every request to Graph. This value can be set with the configuration option `default_access_token` or by using `setDefaultAccessToken()`.
+Returns the default fallback `Facebook\AccessToken` entity that is being used with every request to Graph. This value can be set with the configuration option `default_access_token` or by using `setDefaultAccessToken()`.
 </card>
 
 <card>
 ### setDefaultAccessToken() {#set-default-access-token}
 ~~~~
-public setDefaultAccessToken(string|Facebook\Entities\AccessToken $accessToken)
+public setDefaultAccessToken(string|Facebook\AccessToken $accessToken)
 ~~~~
 
-Sets the default access token to be use with all requests sent to Graph. The access token can be in string or `Facebook\Entities\AccessToken` format.
+Sets the default access token to be use with all requests sent to Graph. The access token can be in string or `Facebook\AccessToken` format.
 
 ~~~~
 $fb->setDefaultAccessToken('{my-access-token}');
 
 // . . . OR . . .
 
-$accessToken = new Facebook\Entities\AccessToken('{my-access-token}');
+$accessToken = new Facebook\AccessToken('{my-access-token}');
 $fb->setDefaultAccessToken($accessToken);
 ~~~~
 
@@ -222,7 +222,7 @@ Returns the default version of Graph. If the `default_graph_version` configurati
 <card>
 ### get() {#get}
 ~~~~
-public Facebook\Entities\FacebookResponse get(
+public Facebook\FacebookResponse get(
   string $endpoint,
   string|AccessToken|null $accessToken,
   string|null $eTag,
@@ -230,7 +230,7 @@ public Facebook\Entities\FacebookResponse get(
 )
 ~~~~
 
-Sends a GET request to Graph and returns a `Facebook\Entities\FacebookResponse`.
+Sends a GET request to Graph and returns a `Facebook\FacebookResponse`.
 
 `$endpoint`
 The url to send to Graph without the version prefix (required).
@@ -240,7 +240,7 @@ $fb->get('/me');
 ~~~
 
 `$accessToken`
-The access token (as a `string` or `Facebook\Entities\AccessToken`) to use for the request. If none is provided, the SDK will assume the value from the `default_access_token` configuration option if it was set.
+The access token (as a `string` or `Facebook\AccessToken`) to use for the request. If none is provided, the SDK will assume the value from the `default_access_token` configuration option if it was set.
 
 `$eTag`
 [Graph supports eTags](https://developers.facebook.com/docs/reference/ads-api/etags-reference/). Set this to the eTag from a previous request to get a `304 Not Modified` response if the data has not changed.
@@ -252,7 +252,7 @@ Set the Graph version to something other than what was set in the `default_graph
 <card>
 ### post() {#post}
 ~~~~
-public Facebook\Entities\FacebookResponse post(
+public Facebook\FacebookResponse post(
   string $endpoint,
   array $params,
   string|AccessToken|null $accessToken,
@@ -261,7 +261,7 @@ public Facebook\Entities\FacebookResponse post(
 )
 ~~~~
 
-Sends a POST request to Graph and returns a `Facebook\Entities\FacebookResponse`.
+Sends a POST request to Graph and returns a `Facebook\FacebookResponse`.
 
 The arguments are the same as `get()` above with the exception of `$params`.
 
@@ -276,7 +276,7 @@ $response = $fb->post('/me/feed', ['message' => 'Foo message']);
 <card>
 ### delete() {#delete}
 ~~~~
-public Facebook\Entities\FacebookResponse delete(
+public Facebook\FacebookResponse delete(
   string $endpoint,
   string|AccessToken|null $accessToken,
   string|null $eTag,
@@ -284,7 +284,7 @@ public Facebook\Entities\FacebookResponse delete(
 )
 ~~~~
 
-Sends a DELETE request to Graph and returns a `Facebook\Entities\FacebookResponse`.
+Sends a DELETE request to Graph and returns a `Facebook\FacebookResponse`.
 
 The arguments are the same as `get()` above.
 
@@ -296,7 +296,7 @@ $response = $fb->delete('/{node-id}');
 <card>
 ### request() {#request}
 ~~~~
-public Facebook\Entities\FacebookRequest request(
+public Facebook\FacebookRequest request(
   string $method,
   string $endpoint,
   array $params,
@@ -306,7 +306,7 @@ public Facebook\Entities\FacebookRequest request(
 )
 ~~~~
 
-Instantiates a new `Facebook\Entities\FacebookRequest` entity **but does not send the request to Graph**. This is useful for creating a number of requests to be sent later in a batch request (see `sendBatchRequest()` below).
+Instantiates a new `Facebook\FacebookRequest` entity **but does not send the request to Graph**. This is useful for creating a number of requests to be sent later in a batch request (see `sendBatchRequest()` below).
 
 The arguments are the same as `post()` above with the exception of `$method`.
 
@@ -321,7 +321,7 @@ $request = $fb->request('GET', '/{node-id}');
 <card>
 ### sendRequest() {#send-request}
 ~~~~
-public Facebook\Entities\FacebookResponse sendRequest(
+public Facebook\FacebookResponse sendRequest(
   string $method,
   string $endpoint,
   array $params,
@@ -341,19 +341,19 @@ $response = $fb->sendRequest('GET', '/me', [], '{access-token}', 'eTag', 'v2.2')
 <card>
 ### sendBatchRequest() {#send-batch-request}
 ~~~~
-public Facebook\Entities\FacebookBatchResponse sendBatchRequest(
+public Facebook\FacebookBatchResponse sendBatchRequest(
   array $requests,
   string|AccessToken|null $accessToken,
   string|null $graphVersion
 )
 ~~~~
 
-Sends an array of `Facebook\Entities\FacebookRequest` entities as a batch request to Graph.
+Sends an array of `Facebook\FacebookRequest` entities as a batch request to Graph.
 
 The `$accessToken` and `$graphVersion` arguments are the same as `get()` above.
 
 `$requests`
-An array of `Facebook\Entities\FacebookRequest` entities. This can be a numeric or associative array but every value of the array has to be of type `Facebook\Entities\FacebookRequest`.
+An array of `Facebook\FacebookRequest` entities. This can be a numeric or associative array but every value of the array has to be of type `Facebook\FacebookRequest`.
 
 If the requests are sent as an associative array, the key will be used as the `name` of the request so that it can be referenced by another request. See more on [batch request naming and using JSONPath](https://developers.facebook.com/docs/graph-api/making-multiple-requests/#operations).
 

--- a/docs/FacebookApp.fbmd
+++ b/docs/FacebookApp.fbmd
@@ -1,19 +1,19 @@
 <card>
 # FacebookApp for the Facebook SDK for PHP
 
-In order to make requests to the Graph API, you need to [create a Facebook app](https://developers.facebook.com/apps) and obtain the app ID and the app secret. The `Facebook\Entities\FacebookApp` entity represents the Facebook app that is making the requests to the Graph API.
+In order to make requests to the Graph API, you need to [create a Facebook app](https://developers.facebook.com/apps) and obtain the app ID and the app secret. The `Facebook\FacebookApp` entity represents the Facebook app that is making the requests to the Graph API.
 </card>
 
 <card>
-## Facebook\Entities\FacebookApp {#overview}
+## Facebook\FacebookApp {#overview}
 
-To instantiate a new `Facebook\Entities\FacebookApp` entity, pass the app ID and app secret to the constructor.
+To instantiate a new `Facebook\FacebookApp` entity, pass the app ID and app secret to the constructor.
 
 ~~~~
-$fbApp = new Facebook\Entities\FacebookApp('{app-id}', '{app-secret}');
+$fbApp = new Facebook\FacebookApp('{app-id}', '{app-secret}');
 ~~~~
 
-Alternatively you can obtain the `Facebook\Entities\FacebookApp` entity from the [`Facebook\Facebook`](/docs/php/Facebook) super service class.
+Alternatively you can obtain the `Facebook\FacebookApp` entity from the [`Facebook\Facebook`](/docs/php/Facebook) super service class.
 
 ~~~~
 $fb = new Facebook\Facebook([/* . . . */]);
@@ -28,9 +28,9 @@ In the most common cases, you'll rarely be using the `FacebookApp` entity direct
 
 ### getAccessToken() {#get-access-token}
 ~~~~
-public Facebook\Entities\AccessToken getAccessToken()
+public Facebook\AccessToken getAccessToken()
 ~~~~
-Returns an app access token in the form of a [`Facebook\Entities\AccessToken`](/docs/php/AccessToken) entity.
+Returns an app access token in the form of a [`Facebook\AccessToken`](/docs/php/AccessToken) entity.
 </card>
 
 <card>
@@ -52,13 +52,13 @@ Returns an the app secret.
 <card>
 ## Serialization {#serialization}
 
-The `Facebook\Entities\FacebookApp` entity implements the `\Serializable` interface so it can be serialized and unserialized.
+The `Facebook\FacebookApp` entity implements the `\Serializable` interface so it can be serialized and unserialized.
 
 ~~~~
-$fbApp = new Facebook\Entities\FacebookApp('foo-app-id', 'foo-app-secret');
+$fbApp = new Facebook\FacebookApp('foo-app-id', 'foo-app-secret');
 
 $serializedFacebookApp = serialize($fbApp);
-// C:29:"Facebook\\Entities\\FacebookApp":54:{a:2:{i:0;s:10:"foo-app-id";i:1;s:14:"foo-app-secret";}}
+// C:29:"Facebook\\FacebookApp":54:{a:2:{i:0;s:10:"foo-app-id";i:1;s:14:"foo-app-secret";}}
 
 $unserializedFacebookApp = unserialize($serializedFacebookApp);
 echo $unserializedFacebookApp->getAccessToken();

--- a/docs/FacebookBatchRequest.fbmd
+++ b/docs/FacebookBatchRequest.fbmd
@@ -5,34 +5,34 @@ Represents a batch request that will be sent to the Graph API.
 </card>
 
 <card>
-## Facebook\Entities\FacebookBatchRequest {#overview}
+## Facebook\FacebookBatchRequest {#overview}
 
 You can instantiate a new `FacebookBatchRequest` entity directly by sending the arguments to the constructor.
 
 ~~~~
-use Facebook\Entities\FacebookBatchRequest;
+use Facebook\FacebookBatchRequest;
 
 $request = new FacebookBatchRequest(
-  Facebook\Entities\FacebookApp $app,
+  Facebook\FacebookApp $app,
   array $requests,
   string|null $accessToken,
   string|null $graphVersion
 );
 ~~~~
 
-The `$requests` array is an array of [`Facebook\Entities\FacebookRequest`'s](/docs/php/FacebookRequest) to be sent as a batch request.
+The `$requests` array is an array of [`Facebook\FacebookRequest`'s](/docs/php/FacebookRequest) to be sent as a batch request.
 
 The `FacebookBatchRequest` entity does not actually make any calls to the Graph API, but instead just represents a batch request that can be sent to the Graph API later. The batch request can be sent by using [`Facebook\Facebook::sendBatchRequest()`](/docs/php/Facebook#send-batch-request) or [`Facebook\FacebookClient::sendBatchRequest()`](/docs/php/FacebookClient#send-batch-request).
 
 Usage:
 
 ~~~~
-$fbApp = new Facebook\Entities\FacebookApp('{app-id}', '{app-secret}');
+$fbApp = new Facebook\FacebookApp('{app-id}', '{app-secret}');
 $requests = [
-  new Facebook\Entities\FacebookRequest(/* */),
-  new Facebook\Entities\FacebookRequest(/* */),
+  new Facebook\FacebookRequest(/* */),
+  new Facebook\FacebookRequest(/* */),
 ];
-$batchRequest = new Facebook\Entities\FacebookBatchRequest($fbApp, $requests, '{access-token}');
+$batchRequest = new Facebook\FacebookBatchRequest($fbApp, $requests, '{access-token}');
 
 // Send the batch request to Graph
 try {
@@ -82,16 +82,16 @@ foreach ($batchResponse as $key => $response) {
 <card>
 ## Instance Methods {#instance-methods}
 
-Since the `Facebook\Entities\FacebookBatchRequest` is extended from the [`Facebook\Entities\FacebookRequest`](/docs/php/FacebookRequest) entity, all the methods are inherited.
+Since the `Facebook\FacebookBatchRequest` is extended from the [`Facebook\FacebookRequest`](/docs/php/FacebookRequest) entity, all the methods are inherited.
 
 ### add() {#add}
 ~~~~
 public add(
-  array|Facebook\Entities\FacebookBatchRequest $request,
+  array|Facebook\FacebookBatchRequest $request,
   string|null $name
   )
 ~~~~
-Adds a request to be sent in the batch request. The `$request` can be a single [`Facebook\Entities\FacebookRequest`](/docs/php/FacebookRequest) or an array of `Facebook\Entities\FacebookRequest`'s.
+Adds a request to be sent in the batch request. The `$request` can be a single [`Facebook\FacebookRequest`](/docs/php/FacebookRequest) or an array of `Facebook\FacebookRequest`'s.
 
 The `$name` argument is optional and is used to identify the request in the batch.
 </card>
@@ -101,13 +101,13 @@ The `$name` argument is optional and is used to identify the request in the batc
 ~~~~
 public array getRequests()
 ~~~~
-Returns the array of [`Facebook\Entities\FacebookRequest`'s](/docs/php/FacebookRequest) to be sent in the batch request.
+Returns the array of [`Facebook\FacebookRequest`'s](/docs/php/FacebookRequest) to be sent in the batch request.
 </card>
 
 <card>
 ## Array Access {#array-access}
 
-Since `Facebook\Entities\FacebookBatchRequest` implements `\IteratorAggregate` and `\ArrayAccess`, the requests can be accessed via array syntax and can also be iterated over.
+Since `Facebook\FacebookBatchRequest` implements `\IteratorAggregate` and `\ArrayAccess`, the requests can be accessed via array syntax and can also be iterated over.
 
 ~~~~
 $fb = new Facebook\Facebook(/* . . . */);
@@ -115,13 +115,13 @@ $requests = [
   'foo' => $fb->request('GET', '/me'),
   'bar' => $fb->request('POST', '/me/feed', [/* */]),
 ];
-$batchRequest = new Facebook\Entities\FacebookBatchRequest($fb->getApp(), $requests, '{access-token}');
+$batchRequest = new Facebook\FacebookBatchRequest($fb->getApp(), $requests, '{access-token}');
 
 var_dump($batchRequest[0]);
 /*
 array(2) {
   'name' => string(3) "foo"
-  'request' => class Facebook\Entities\FacebookRequest
+  'request' => class Facebook\FacebookRequest
   . . .
 */
 ~~~~

--- a/docs/FacebookBatchResponse.fbmd
+++ b/docs/FacebookBatchResponse.fbmd
@@ -5,9 +5,9 @@ Represents a batch response returned from the Graph API.
 </card>
 
 <card>
-## Facebook\Entities\FacebookBatchResponse {#overview}
+## Facebook\FacebookBatchResponse {#overview}
 
-After sending a batch request to the Graph API, the response will be returned in the form of a `Facebook\Entities\FacebookBatchResponse` entity.
+After sending a batch request to the Graph API, the response will be returned in the form of a `Facebook\FacebookBatchResponse` entity.
 
 Usage:
 
@@ -41,26 +41,26 @@ foreach ($batchResponse as $key => $response) {
 }
 
 var_dump($batchResponse);
-// class Facebook\Entities\FacebookBatchResponse . . .
+// class Facebook\FacebookBatchResponse . . .
 ~~~~
 </card>
 
 <card>
 ## Instance Methods {#instance-methods}
 
-Since the `Facebook\Entities\FacebookBatchResponse` is extended from the [`Facebook\Entities\FacebookResponse`](/docs/php/FacebookResponse) entity, all the methods are inherited.
+Since the `Facebook\FacebookBatchResponse` is extended from the [`Facebook\FacebookResponse`](/docs/php/FacebookResponse) entity, all the methods are inherited.
 
 ### getResponses() {#get-responses}
 ~~~~
 public array getResponses()
 ~~~~
-Returns the array of [`Facebook\Entities\FacebookResponse`](/docs/php/FacebookResponse) entities that were returned from Graph.
+Returns the array of [`Facebook\FacebookResponse`](/docs/php/FacebookResponse) entities that were returned from Graph.
 </card>
 
 <card>
 ## Array Access {#array-access}
 
-Since `Facebook\Entities\FacebookBatchResponse` implements `\IteratorAggregate` and `\ArrayAccess`, the responses can be accessed via array syntax and can also be iterated over.
+Since `Facebook\FacebookBatchResponse` implements `\IteratorAggregate` and `\ArrayAccess`, the responses can be accessed via array syntax and can also be iterated over.
 
 ~~~~
 $requests = [
@@ -79,6 +79,6 @@ foreach ($batchResponse as $key => $response) {
 }
 
 var_dump($batchResponse['foo']);
-// class Facebook\Entities\FacebookResponse . . .
+// class Facebook\FacebookResponse . . .
 ~~~~
 </card>

--- a/docs/FacebookCanvasHelper.fbmd
+++ b/docs/FacebookCanvasHelper.fbmd
@@ -4,7 +4,7 @@
 The `FacebookCanvasHelper` is used to obtain an access token or signed request when working within the context of an [app canvas](https://developers.facebook.com/docs/games/canvas).
 
 ~~~
-Facebook\Helpers\FacebookCanvasHelper( Facebook\Entities\FacebookApp $facebookApp )
+Facebook\Helpers\FacebookCanvasHelper( Facebook\FacebookApp $facebookApp )
 ~~~
 </card>
 
@@ -67,7 +67,7 @@ if (isset($accessToken)) {
 
 ### __construct() {#construct}
 ~~~~
-public FacebookCanvasHelper __construct( Facebook\Entities\FacebookApp $app )
+public FacebookCanvasHelper __construct( Facebook\FacebookApp $app )
 ~~~~
 Upon instantiation, `FacebookCanvasHelper` validates and decrypts the signed request that was sent via POST if present.
 </card>
@@ -75,7 +75,7 @@ Upon instantiation, `FacebookCanvasHelper` validates and decrypts the signed req
 <card>
 ### getAccessToken() {#get-access-token}
 ~~~
-public Facebook\Entities\AccessToken|null getAccessToken( Facebook\FacebookClient $client )
+public Facebook\AccessToken|null getAccessToken( Facebook\FacebookClient $client )
 ~~~
 Checks the signed request for authentication data and tries to obtain an access token access token.
 </card>
@@ -119,9 +119,9 @@ Gets the value that is set in the `app_data` property if present.
 <card>
 ### getSignedRequest() {#get-signed-request}
 ~~~
-public Facebook\Entities\SignedRequest|null getSignedRequest()
+public Facebook\SignedRequest|null getSignedRequest()
 ~~~
-Returns the signed request as a [`Facebook\Entities\SignedRequest`](/docs/php/SignedRequest) entity if present.
+Returns the signed request as a [`Facebook\SignedRequest`](/docs/php/SignedRequest) entity if present.
 </card>
 
 <card>

--- a/docs/FacebookClient.fbmd
+++ b/docs/FacebookClient.fbmd
@@ -19,7 +19,7 @@ $fbClient = $fb->getClient();
 Alternatively you could instantiate a new `Facebook\FacebookClient` service directly.
 
 ~~~~
-$fbApp = new Facebook\Entities\FacebookApp('{app_id}', '{app_secret}');
+$fbApp = new Facebook\FacebookApp('{app_id}', '{app_secret}');
 $fbClient = new Facebook\FacebookClient($fbApp, $enableBeta = false);
 ~~~~
 
@@ -57,13 +57,13 @@ Tells the service to send requests to the beta URL's which include [https://grap
 <card>
 ### sendRequest() {#send-request}
 ~~~~
-public Facebook\Entities\FacebookResponse sendRequest(Facebook\Entities\FacebookRequest $request)
+public Facebook\FacebookResponse sendRequest(Facebook\FacebookRequest $request)
 ~~~~
 Sends a non-batch request to Graph.
 
-Takes a [`Facebook\Entities\FacebookRequest`](/docs/php/FacebookRequest) and sends it to the Graph API in the proper `application/x-www-form-urlencoded` or `multipart/form-data` encoded format.
+Takes a [`Facebook\FacebookRequest`](/docs/php/FacebookRequest) and sends it to the Graph API in the proper `application/x-www-form-urlencoded` or `multipart/form-data` encoded format.
 
-Returns the response from Graph in the form of a [`Facebook\Entities\FacebookResponse`](/docs/php/FacebookResponse).
+Returns the response from Graph in the form of a [`Facebook\FacebookResponse`](/docs/php/FacebookResponse).
 
 If there was an error processing the request before sending, a [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException) will be thrown.
 
@@ -73,13 +73,13 @@ If an error response from Graph was returned, a [`Facebook\Exceptions\FacebookRe
 <card>
 ### sendBatchRequest() {#send-batch-request}
 ~~~~
-public Facebook\Entities\FacebookBatchResponse sendBatchRequest(Facebook\Entities\FacebookBatchRequest $batchRequest)
+public Facebook\FacebookBatchResponse sendBatchRequest(Facebook\FacebookBatchRequest $batchRequest)
 ~~~~
 Sends a batch request to Graph.
 
-Takes a [`Facebook\Entities\FacebookBatchRequest`](/docs/php/FacebookBatchRequest) and sends it to the Graph API in the proper `application/x-www-form-urlencoded` or `multipart/form-data` encoded format.
+Takes a [`Facebook\FacebookBatchRequest`](/docs/php/FacebookBatchRequest) and sends it to the Graph API in the proper `application/x-www-form-urlencoded` or `multipart/form-data` encoded format.
 
-Returns the response from Graph in the form of a [`Facebook\Entities\FacebookBatchResponse`](/docs/php/FacebookBatchResponse).
+Returns the response from Graph in the form of a [`Facebook\FacebookBatchResponse`](/docs/php/FacebookBatchResponse).
 
 If there was an error processing the request before sending, a [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException) will be thrown.
 

--- a/docs/FacebookJavaScriptHelper.fbmd
+++ b/docs/FacebookJavaScriptHelper.fbmd
@@ -65,7 +65,7 @@ It's important to note that on first access, or if a session has since expired, 
 
 ### __construct() {#construct}
 ~~~~
-public FacebookJavaScriptHelper __construct( Facebook\Entities\FacebookApp $app )
+public FacebookJavaScriptHelper __construct( Facebook\FacebookApp $app )
 ~~~~
 Upon instantiation, `FacebookJavaScriptHelper` validates and decrypts the signed request that exists in the cookie set by the JavaScript SDK if present.
 </card>
@@ -73,7 +73,7 @@ Upon instantiation, `FacebookJavaScriptHelper` validates and decrypts the signed
 <card>
 ### getAccessToken() {#get-access-token}
 ~~~
-public Facebook\Entities\AccessToken|null getAccessToken( Facebook\FacebookClient $client )
+public Facebook\AccessToken|null getAccessToken( Facebook\FacebookClient $client )
 ~~~
 Checks the signed request for authentication data and tries to obtain an access token access token.
 </card>
@@ -109,9 +109,9 @@ if ($signedRequest) {
 <card>
 ### getSignedRequest() {#get-signed-request}
 ~~~
-public Facebook\Entities\SignedRequest|null getSignedRequest()
+public Facebook\SignedRequest|null getSignedRequest()
 ~~~
-Returns the signed request as a [`Facebook\Entities\SignedRequest`](/docs/php/SignedRequest) entity if present.
+Returns the signed request as a [`Facebook\SignedRequest`](/docs/php/SignedRequest) entity if present.
 </card>
 
 <card>

--- a/docs/FacebookRequest.fbmd
+++ b/docs/FacebookRequest.fbmd
@@ -5,15 +5,15 @@ Represents a request that will be sent to the Graph API.
 </card>
 
 <card>
-## Facebook\Entities\FacebookRequest {#overview}
+## Facebook\FacebookRequest {#overview}
 
 You can instantiate a new `FacebookRequest` entity directly by sending the arguments to the constructor.
 
 ~~~~
-use Facebook\Entities\FacebookRequest;
+use Facebook\FacebookRequest;
 
 $request = new FacebookRequest(  
-  Facebook\Entities\FacebookApp $app,
+  Facebook\FacebookApp $app,
   string $accessToken,
   string $method,
   string $endpoint,
@@ -30,8 +30,8 @@ The `FacebookRequest` entity does not actually make any calls to the Graph API, 
 Usage:
 
 ~~~~
-$fbApp = new Facebook\Entities\FacebookApp('{app-id}', '{app-secret}');
-$request = new Facebook\Entities\FacebookRequest($fbApp, '{access-token}', 'GET', '/me');
+$fbApp = new Facebook\FacebookApp('{app-id}', '{app-secret}');
+$request = new Facebook\FacebookRequest($fbApp, '{access-token}', 'GET', '/me');
 
 // OR
 
@@ -62,7 +62,7 @@ echo 'User name: ' . $object['name'];
 
 ### setAccessToken() {#set-access-token}
 ~~~~
-public setAccessToken(string|Facebook\Entities\AccessToken $accessToken)
+public setAccessToken(string|Facebook\AccessToken $accessToken)
 ~~~~
 Sets the access token to be used for the request.
 </card>
@@ -78,17 +78,17 @@ Returns the access token to be used for the request in the form of a string.
 <card>
 ### setApp() {#set-app}
 ~~~~
-public setApp(Facebook\Entities\FacebookApp $app)
+public setApp(Facebook\FacebookApp $app)
 ~~~~
-Sets the [`Facebook\Entities\FacebookApp`](/docs/php/FacebookApp) entity used with this request.
+Sets the [`Facebook\FacebookApp`](/docs/php/FacebookApp) entity used with this request.
 </card>
 
 <card>
 ### getApp() {#get-app}
 ~~~~
-public Facebook\Entities\FacebookApp getApp()
+public Facebook\FacebookApp getApp()
 ~~~~
-Returns the [`Facebook\Entities\FacebookApp`](/docs/php/FacebookApp) entity used with this request.
+Returns the [`Facebook\FacebookApp`](/docs/php/FacebookApp) entity used with this request.
 </card>
 
 <card>

--- a/docs/FacebookResponse.fbmd
+++ b/docs/FacebookResponse.fbmd
@@ -5,9 +5,9 @@ Represents a response from the Graph API.
 </card>
 
 <card>
-## Facebook\Entities\FacebookResponse {#overview}
+## Facebook\FacebookResponse {#overview}
 
-After sending a request to the Graph API, the response will be returned in the form of a `Facebook\Entities\FacebookResponse` entity.
+After sending a request to the Graph API, the response will be returned in the form of a `Facebook\FacebookResponse` entity.
 
 Usage:
 
@@ -28,7 +28,7 @@ try {
 }
 
 var_dump($response);
-// class Facebook\Entities\FacebookResponse . . .
+// class Facebook\FacebookResponse . . .
 ~~~~
 </card>
 
@@ -37,9 +37,9 @@ var_dump($response);
 
 ### getRequest() {#get-request}
 ~~~~
-public Facebook\Entities\FacebookRequest getRequest()
+public Facebook\FacebookRequest getRequest()
 ~~~~
-Returns the original [`Facebook\Entities\FacebookRequest`](/docs/php/FacebookRequest) entity that was used to solicit this response.
+Returns the original [`Facebook\FacebookRequest`](/docs/php/FacebookRequest) entity that was used to solicit this response.
 </card>
 
 <card>
@@ -53,9 +53,9 @@ Returns the access token that was used for the original request in the form of a
 <card>
 ### getApp() {#get-app}
 ~~~~
-public Facebook\Entities\FacebookApp getApp()
+public Facebook\FacebookApp getApp()
 ~~~~
-Returns the [`Facebook\Entities\FacebookApp`](/docs/php/FacebookApp) entity that was used with the original request.
+Returns the [`Facebook\FacebookApp`](/docs/php/FacebookApp) entity that was used with the original request.
 </card>
 
 <card>

--- a/docs/FacebookSDKException.fbmd
+++ b/docs/FacebookSDKException.fbmd
@@ -7,7 +7,7 @@ Represents an exception thrown by the SDK.
 <card>
 ## Facebook\Exceptions\FacebookSDKException {#overview}
 
-A `FacebookSDKException` is thrown when something goes wrong. For example if an invalid signed request is sent to the `Facebook\Entities\SignedRequest` entity, it will throw an `FacebookSDKException`.
+A `FacebookSDKException` is thrown when something goes wrong. For example if an invalid signed request is sent to the `Facebook\SignedRequest` entity, it will throw an `FacebookSDKException`.
 
 When an error response is returned from the Graph API, it will be thrown as a `FacebookSDKException` subtype called a [Facebook\Exceptions\FacebookResponseException](/docs/php/FacebookResponseException).
 </card>

--- a/docs/GraphObject.fbmd
+++ b/docs/GraphObject.fbmd
@@ -15,13 +15,13 @@ This base class has several subclasses:
 [__GraphLocation__](#location-instance-methods)
 [__GraphSessionInfo__](#sessioninfo-instance-methods)
 
-`GraphObject`'s are obtained from a [`Facebook\Entities\FacebookResponse`](/docs/php/FacebookResponse) object which represents a response from the Graph API.
+`GraphObject`'s are obtained from a [`Facebook\FacebookResponse`](/docs/php/FacebookResponse) object which represents a response from the Graph API.
 
 Usage:
 
 ~~~~
 $fb = new Facebook\Facebook(\* *\);
-// Returns a `Facebook\Entities\FacebookResponse` object
+// Returns a `Facebook\FacebookResponse` object
 $response = $fb->get('/something');
 
 // Get the base class GraphObject from the response

--- a/docs/SignedRequest.fbmd
+++ b/docs/SignedRequest.fbmd
@@ -1,22 +1,22 @@
 <card>
 # SignedRequest entity for the Facebook SDK for PHP
 
-The `Facebook\Entities\SignedRequest` entity represents a signed request.
+The `Facebook\SignedRequest` entity represents a signed request.
 </card>
 
 <card>
-## Facebook\Entities\SignedRequest {#overview}
+## Facebook\SignedRequest {#overview}
 
-[Signed requests](https://developers.facebook.com/docs/facebook-login/using-login-with-games#checklogin) contain payloads of data that can be validated against a hash signature to ensure it is from Facebook. The `Facebook\Entities\SignedRequest` entity can validate a signed request signature and decode the payload.
+[Signed requests](https://developers.facebook.com/docs/facebook-login/using-login-with-games#checklogin) contain payloads of data that can be validated against a hash signature to ensure it is from Facebook. The `Facebook\SignedRequest` entity can validate a signed request signature and decode the payload.
 
-To instantiate a new `Facebook\Entities\SignedRequest` entity, pass the [`Facebook\Entities\FacebookApp`](/docs/php/FacebookApp) entity and raw signed request to the constructor.
+To instantiate a new `Facebook\SignedRequest` entity, pass the [`Facebook\FacebookApp`](/docs/php/FacebookApp) entity and raw signed request to the constructor.
 
 ~~~~
-$fbApp = new Facebook\Entities\FacebookApp('{app-id}', '{app-secret}');
-$signedRequest = new Facebook\Entities\SignedRequest($fbApp, 'raw.signed_request');
+$fbApp = new Facebook\FacebookApp('{app-id}', '{app-secret}');
+$signedRequest = new Facebook\SignedRequest($fbApp, 'raw.signed_request');
 ~~~~
 
-Usually `Facebook\Entities\SignedRequest` entities are obtained using one of the [helpers](/docs/php/sdk_reference#helpers).
+Usually `Facebook\SignedRequest` entities are obtained using one of the [helpers](/docs/php/sdk_reference#helpers).
 
 ~~~~
 $fb = new Facebook\Facebook([/* . . . */]);
@@ -82,11 +82,11 @@ Returns `true` if the payload data contains either an `oauth_token` or `code` fi
 ~~~~
 public string make(array $payload)
 ~~~~
-Generates a valid raw signed request as a string that contains the data from the `$payload` array. The signature is signed using the app secret from the `Facebook\Entities\FacebookApp` entity. This can be useful for testing purposes.
+Generates a valid raw signed request as a string that contains the data from the `$payload` array. The signature is signed using the app secret from the `Facebook\FacebookApp` entity. This can be useful for testing purposes.
 
 ~~~~
-$fbApp = new Facebook\Entities\FacebookApp('{app-id}', '{app-secret}');
-$signedRequest = new Facebook\Entities\SignedRequest($fbApp);
+$fbApp = new Facebook\FacebookApp('{app-id}', '{app-secret}');
+$signedRequest = new Facebook\SignedRequest($fbApp);
 
 $payload = [
   'algorithm' => 'HMAC-SHA256',

--- a/docs/post_links.fbmd
+++ b/docs/post_links.fbmd
@@ -5,7 +5,7 @@ This example covers posting a link to the current user's timeline using the Grap
 
 It assumes that you've already obtained an access token from one of the helpers found [here](/docs/php/sdk_reference#helpers). The access token must have the `publish_actions` permission for this to work.
 
-For more information, see the documentation for [`Facebook\Facebook`](/docs/php/Facebook), [`Facebook\Entities\FacebookResponse`](/docs/php/FacebookResponse), [`Facebook\GraphNodes\GraphObject`](/docs/php/GraphObject), [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException) and [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException).
+For more information, see the documentation for [`Facebook\Facebook`](/docs/php/Facebook), [`Facebook\FacebookResponse`](/docs/php/FacebookResponse), [`Facebook\GraphNodes\GraphObject`](/docs/php/GraphObject), [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException) and [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException).
 </card>
 
 <card>
@@ -23,7 +23,7 @@ $linkData = [
   ];
 
 try {
-  // Returns a `Facebook\Entities\FacebookResponse` object
+  // Returns a `Facebook\FacebookResponse` object
   $response = $fb->post('/me/feed', $linkData, '{access-token}');
 } catch(Facebook\Exceptions\FacebookResponseException $e) {
   echo 'Graph returned an error: ' . $e->getMessage();

--- a/docs/retrieve_user_profile.fbmd
+++ b/docs/retrieve_user_profile.fbmd
@@ -5,7 +5,7 @@ This example covers getting profile information for the current user and printin
 
 It assumes that you've already obtained an access token from one of the helpers found [here](/docs/php/sdk_reference#helpers).
 
-For more information, see the documentation for [`Facebook\Facebook`](/docs/php/Facebook), [`Facebook\Entities\FacebookResponse`](/docs/php/FacebookResponse), [`Facebook\GraphNodes\GraphUser`](/docs/php/GraphObject#user-instance-methods), [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException) and [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException).
+For more information, see the documentation for [`Facebook\Facebook`](/docs/php/Facebook), [`Facebook\FacebookResponse`](/docs/php/FacebookResponse), [`Facebook\GraphNodes\GraphUser`](/docs/php/GraphObject#user-instance-methods), [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException) and [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException).
 
 </card>
 
@@ -19,7 +19,7 @@ $fb = new Facebook\Facebook([
   ]);
 
 try {
-  // Returns a `Facebook\Entities\FacebookResponse` object
+  // Returns a `Facebook\FacebookResponse` object
   $response = $fb->get('/me?fields=id,name', '{access-token}');
 } catch(Facebook\Exceptions\FacebookResponseException $e) {
   echo 'Graph returned an error: ' . $e->getMessage();

--- a/docs/sdk_getting_started.fbmd
+++ b/docs/sdk_getting_started.fbmd
@@ -106,10 +106,10 @@ require_once __DIR__ . '/facebook-sdk-v4.1/autoload.php';
 
 ### The `FacebookApp` entity
 
-Before we can send requests to the Graph API, we need to load our app configuration into a `Facebook\Entities\FacebookApp` entity.
+Before we can send requests to the Graph API, we need to load our app configuration into a `Facebook\FacebookApp` entity.
 
 ~~~
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 
 $facebookApp = new FacebookApp('{app-id}', '{app-secret}');
 ~~~
@@ -143,7 +143,7 @@ For most websites, you'll use the `[Facebook\Helpers\FacebookRedirectLoginHelper
 
 ~~~
 # login.php
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 use Facebook\Helpers\FacebookRedirectLoginHelper;
 
 $facebookApp = new FacebookApp('{app-id}', '{app-secret}');
@@ -157,7 +157,7 @@ echo '<a href="' . $loginUrl . '">Log in with Facebook!</a>';
 
 ~~~
 # login-callback.php
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 use Facebook\FacebookClient;
 use Facebook\Helpers\FacebookRedirectLoginHelper;
 use Facebook\Exceptions\FacebookResponseException;
@@ -182,10 +182,10 @@ if (isset($accessToken)) {
 }
 ~~~
 
-If your app is on Facebook Canvas, use the `getAccessToken()` method on [FacebookCanvasLoginHelper](/docs/php/FacebookCanvasLoginHelper) to get an `Facebook\Entities\AccessToken` entity for the user.
+If your app is on Facebook Canvas, use the `getAccessToken()` method on [FacebookCanvasLoginHelper](/docs/php/FacebookCanvasLoginHelper) to get an `Facebook\AccessToken` entity for the user.
 
 ~~~
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 use Facebook\FacebookClient;
 use Facebook\Helpers\FacebookCanvasLoginHelper;
 use Facebook\Exceptions\FacebookResponseException;
@@ -212,10 +212,10 @@ if (isset($accessToken)) {
 }
 ~~~
 
-If you're already using the Facebook SDK for JavaScript to authenticate users, you can also log them in on the server side with the [FacebookJavaScriptLoginHelper](/docs/php/FacebookJavaScriptLoginHelper).  The `getAccessToken()` method will return a `Facebook\Entities\AccessToken` entity.
+If you're already using the Facebook SDK for JavaScript to authenticate users, you can also log them in on the server side with the [FacebookJavaScriptLoginHelper](/docs/php/FacebookJavaScriptLoginHelper).  The `getAccessToken()` method will return a `Facebook\AccessToken` entity.
 
 ~~~
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 use Facebook\FacebookClient;
 use Facebook\Helpers\FacebookJavaScriptLoginHelper;
 use Facebook\Exceptions\FacebookResponseException;
@@ -240,10 +240,10 @@ if (isset($accessToken)) {
 }
 ~~~
 
-You can also create a `Facebook\Entities\AccessToken` entity with an access token you've acquired through some other means, by passing it to the constructor.
+You can also create a `Facebook\AccessToken` entity with an access token you've acquired through some other means, by passing it to the constructor.
 
 ~~~
-use Facebook\Entities\AccessToken;
+use Facebook\AccessToken;
 
 $accessToken = new AccessToken('{access-token}');
 ~~~
@@ -252,11 +252,11 @@ $accessToken = new AccessToken('{access-token}');
 <card>
 ## Making Requests to the Graph API {#making-requests}
 
-Once you have created a `Facebook\Entities\FacebookApp` entity, instantiated a `Facebook\FacebookClient` and obtained an access token, you can begin making calls to the Graph API with the [`Facebook\Entities\FacebookRequest`](/docs/php/FacebookRequest) entity.
+Once you have created a `Facebook\FacebookApp` entity, instantiated a `Facebook\FacebookClient` and obtained an access token, you can begin making calls to the Graph API with the [`Facebook\FacebookRequest`](/docs/php/FacebookRequest) entity.
 
 ~~~
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
+use Facebook\FacebookApp;
+use Facebook\FacebookRequest;
 use Facebook\FacebookClient;
 use Facebook\GraphNodes\GraphUser;
 use Facebook\Exceptions\FacebookResponseException;

--- a/docs/sdk_reference.fbmd
+++ b/docs/sdk_reference.fbmd
@@ -33,31 +33,31 @@ FB(devsite:markdown-wiki:table {
   columns: ['Class name','Description',],
   rows: [
     [
-      '`[Facebook\Entities\AccessToken](/docs/php/AccessToken)`',
+      '`[Facebook\AccessToken](/docs/php/AccessToken)`',
       'An entity that represents an access token and is required to send requests to Graph.',
     ],
     [
-      '`[Facebook\Entities\FacebookApp](/docs/php/FacebookApp)`',
+      '`[Facebook\FacebookApp](/docs/php/FacebookApp)`',
       'An entity that represents a Facebook app and is required to send requests to Graph.',
     ],
     [
-      '`[Facebook\Entities\FacebookBatchRequest](/docs/php/FacebookBatchRequest)`',
+      '`[Facebook\FacebookBatchRequest](/docs/php/FacebookBatchRequest)`',
       'An entity that represents a batch request to be sent to Graph.',
     ],
     [
-      '`[Facebook\Entities\FacebookBatchResponse](/docs/php/FacebookBatchResponse)`',
+      '`[Facebook\FacebookBatchResponse](/docs/php/FacebookBatchResponse)`',
       'An entity that represents a response from Graph after sending a batch request.',
     ],
     [
-      '`[Facebook\Entities\FacebookRequest](/docs/php/FacebookRequest)`',
+      '`[Facebook\FacebookRequest](/docs/php/FacebookRequest)`',
       'An entity that represents a request to be sent to Graph.',
     ],
     [
-      '`[Facebook\Entities\FacebookResponse](/docs/php/FacebookResponse)`',
+      '`[Facebook\FacebookResponse](/docs/php/FacebookResponse)`',
       'An entity that represents a response from Graph.',
     ],
     [
-      '`[Facebook\Entities\SignedRequest](/docs/php/SignedRequest)`',
+      '`[Facebook\SignedRequest](/docs/php/SignedRequest)`',
       'An entity that represents a signed request.',
     ],
   ],

--- a/docs/upload_photo.fbmd
+++ b/docs/upload_photo.fbmd
@@ -5,7 +5,7 @@ This example covers uploading a photo to the current User's profile using the Gr
 
 It assumes that you've already acquired an access token using one of the helper classes found [here](/docs/php/sdk_reference#helpers).  The access token must have the `publish_actions` permission for this to work.
 
-For more information, see the documentation for [`Facebook\Facebook`](/docs/php/Facebook), [`Facebook\FileUpload\FacebookFile`](/docs/php/FacebookFile), [`Facebook\Entities\FacebookResponse`](/docs/php/FacebookResponse), [`Facebook\GraphNodes\GraphObject`](/docs/php/GraphObject), [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException) and [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException).
+For more information, see the documentation for [`Facebook\Facebook`](/docs/php/Facebook), [`Facebook\FileUpload\FacebookFile`](/docs/php/FacebookFile), [`Facebook\FacebookResponse`](/docs/php/FacebookResponse), [`Facebook\GraphNodes\GraphObject`](/docs/php/GraphObject), [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException) and [`Facebook\Exceptions\FacebookSDKException`](/docs/php/FacebookSDKException).
 </card>
 
 <card>
@@ -20,7 +20,7 @@ $data = [
 ];
 
 try {
-  // Returns a `Facebook\Entities\FacebookResponse` object
+  // Returns a `Facebook\FacebookResponse` object
   $response = $fb->post('/me/photos', $data);
 } catch(Facebook\Exceptions\FacebookResponseException $e) {
   echo 'Graph returned an error: ' . $e->getMessage();

--- a/src/Facebook/AccessToken.php
+++ b/src/Facebook/AccessToken.php
@@ -21,11 +21,10 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Entities;
+namespace Facebook;
 
 use Facebook\Exceptions\FacebookResponseException;
 use Facebook\Exceptions\FacebookSDKException;
-use Facebook\FacebookClient;
 use Facebook\GraphNodes\GraphSessionInfo;
 
 /**

--- a/src/Facebook/Exceptions/FacebookResponseException.php
+++ b/src/Facebook/Exceptions/FacebookResponseException.php
@@ -23,7 +23,7 @@
  */
 namespace Facebook\Exceptions;
 
-use Facebook\Entities\FacebookResponse;
+use Facebook\FacebookResponse;
 
 /**
  * Class FacebookResponseException

--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -23,12 +23,6 @@
  */
 namespace Facebook;
 
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\AccessToken;
-use Facebook\Entities\FacebookRequest;
-use Facebook\Entities\FacebookBatchRequest;
-use Facebook\Entities\FacebookResponse;
-use Facebook\Entities\FacebookBatchResponse;
 use Facebook\FileUpload\FacebookFile;
 use Facebook\FileUpload\FacebookVideo;
 use Facebook\GraphNodes\GraphList;
@@ -297,7 +291,7 @@ class Facebook
 
     throw new \InvalidArgumentException(
       'The default access token must be of type "string"'
-      . ' or Facebook\Entities\AccessToken'
+      . ' or Facebook\AccessToken'
     );
   }
 

--- a/src/Facebook/FacebookApp.php
+++ b/src/Facebook/FacebookApp.php
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Entities;
+namespace Facebook;
 
 class FacebookApp implements \Serializable
 {

--- a/src/Facebook/FacebookBatchRequest.php
+++ b/src/Facebook/FacebookBatchRequest.php
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Entities;
+namespace Facebook;
 
 use ArrayIterator;
 use IteratorAggregate;

--- a/src/Facebook/FacebookBatchResponse.php
+++ b/src/Facebook/FacebookBatchResponse.php
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Entities;
+namespace Facebook;
 
 use ArrayIterator;
 use IteratorAggregate;

--- a/src/Facebook/FacebookClient.php
+++ b/src/Facebook/FacebookClient.php
@@ -23,10 +23,6 @@
  */
 namespace Facebook;
 
-use Facebook\Entities\FacebookRequest;
-use Facebook\Entities\FacebookBatchRequest;
-use Facebook\Entities\FacebookResponse;
-use Facebook\Entities\FacebookBatchResponse;
 use Facebook\HttpClients\FacebookHttpClientInterface;
 use Facebook\HttpClients\FacebookCurlHttpClient;
 use Facebook\HttpClients\FacebookStreamHttpClient;

--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -21,9 +21,8 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Entities;
+namespace Facebook;
 
-use Facebook\Facebook;
 use Facebook\Url\FacebookUrlManipulator;
 use Facebook\FileUpload\FacebookFile;
 use Facebook\FileUpload\FacebookVideo;

--- a/src/Facebook/FacebookResponse.php
+++ b/src/Facebook/FacebookResponse.php
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Entities;
+namespace Facebook;
 
 use Facebook\GraphNodes\GraphObjectFactory;
 use Facebook\Exceptions\FacebookResponseException;

--- a/src/Facebook/GraphNodes/GraphList.php
+++ b/src/Facebook/GraphNodes/GraphList.php
@@ -23,7 +23,7 @@
  */
 namespace Facebook\GraphNodes;
 
-use Facebook\Entities\FacebookRequest;
+use Facebook\FacebookRequest;
 use Facebook\Url\FacebookUrlManipulator;
 use Facebook\Exceptions\FacebookSDKException;
 

--- a/src/Facebook/GraphNodes/GraphObjectFactory.php
+++ b/src/Facebook/GraphNodes/GraphObjectFactory.php
@@ -23,7 +23,7 @@
  */
 namespace Facebook\GraphNodes;
 
-use Facebook\Entities\FacebookResponse;
+use Facebook\FacebookResponse;
 use Facebook\Exceptions\FacebookSDKException;
 
 /**

--- a/src/Facebook/Helpers/FacebookPageTabHelper.php
+++ b/src/Facebook/Helpers/FacebookPageTabHelper.php
@@ -23,7 +23,7 @@
  */
 namespace Facebook\Helpers;
 
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 
 /**
  * Class FacebookPageTabHelper

--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -24,8 +24,8 @@
 namespace Facebook\Helpers;
 
 use Facebook\Facebook;
-use Facebook\Entities\AccessToken;
-use Facebook\Entities\FacebookApp;
+use \Facebook\AccessToken;
+use \Facebook\FacebookApp;
 use Facebook\Url\UrlDetectionInterface;
 use Facebook\Url\FacebookUrlDetectionHandler;
 use Facebook\Url\FacebookUrlManipulator;

--- a/src/Facebook/Helpers/FacebookSignedRequestFromInputHelper.php
+++ b/src/Facebook/Helpers/FacebookSignedRequestFromInputHelper.php
@@ -23,9 +23,9 @@
  */
 namespace Facebook\Helpers;
 
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\SignedRequest;
-use Facebook\Entities\AccessToken;
+use Facebook\FacebookApp;
+use Facebook\SignedRequest;
+use Facebook\AccessToken;
 use Facebook\FacebookClient;
 
 /**

--- a/src/Facebook/SignedRequest.php
+++ b/src/Facebook/SignedRequest.php
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Entities;
+namespace Facebook;
 
 use Facebook\Exceptions\FacebookSDKException;
 

--- a/tests/AccessTokenTest.php
+++ b/tests/AccessTokenTest.php
@@ -21,11 +21,11 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Tests\Entities;
+namespace Facebook\Tests;
 
 use Mockery as m;
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\AccessToken;
+use Facebook\FacebookApp;
+use Facebook\AccessToken;
 use Facebook\GraphNodes\GraphSessionInfo;
 
 class AccessTokenTest extends \PHPUnit_Framework_TestCase
@@ -133,7 +133,7 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
 
     $longLivedAccessToken = $accessToken->extend($app, $client);
 
-    $this->assertInstanceOf('Facebook\Entities\AccessToken', $longLivedAccessToken);
+    $this->assertInstanceOf('Facebook\AccessToken', $longLivedAccessToken);
     $this->assertEquals('long_token', (string)$longLivedAccessToken);
     $this->assertEquals('foo_machine', $longLivedAccessToken->getMachineId());
     $this->assertEquals(time() + 123, $longLivedAccessToken->getExpiresAt()->getTimeStamp());
@@ -164,7 +164,7 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
 
     $accessTokenFromCode = AccessToken::getAccessTokenFromCode('foo_code', $app, $client);
 
-    $this->assertInstanceOf('Facebook\Entities\AccessToken', $accessTokenFromCode);
+    $this->assertInstanceOf('Facebook\AccessToken', $accessTokenFromCode);
     $this->assertEquals('new_long_token', (string)$accessTokenFromCode);
     $this->assertEquals('foo_machine', $accessTokenFromCode->getMachineId());
     $this->assertEquals(time() + 123, $accessTokenFromCode->getExpiresAt()->getTimeStamp());
@@ -201,7 +201,7 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
     $client = m::mock('Facebook\FacebookClient');
     $client
       ->shouldReceive('sendRequest')
-      ->with(m::type('Facebook\Entities\FacebookRequest'))
+      ->with(m::type('Facebook\FacebookRequest'))
       ->once()
       ->andReturn($response);
     return $client;
@@ -219,7 +219,7 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
 
   private function createFacebookResponseMock()
   {
-    return m::mock('Facebook\Entities\FacebookResponse');
+    return m::mock('Facebook\FacebookResponse');
   }
 
   private function createFacebookResponseMockWithNoExpiresAt()

--- a/tests/Exceptions/FacebookResponseExceptionTest.php
+++ b/tests/Exceptions/FacebookResponseExceptionTest.php
@@ -23,9 +23,9 @@
  */
 namespace Facebook\Tests\Exceptions;
 
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
-use Facebook\Entities\FacebookResponse;
+use Facebook\FacebookApp;
+use Facebook\FacebookRequest;
+use Facebook\FacebookResponse;
 use Facebook\Exceptions\FacebookResponseException;
 
 class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase

--- a/tests/FacebookAppTest.php
+++ b/tests/FacebookAppTest.php
@@ -21,9 +21,9 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Tests\Entities;
+namespace Facebook\Tests;
 
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 
 class FacebookAppTest extends \PHPUnit_Framework_TestCase
 {
@@ -52,7 +52,7 @@ class FacebookAppTest extends \PHPUnit_Framework_TestCase
   {
     $accessToken = $this->app->getAccessToken();
 
-    $this->assertInstanceOf('Facebook\Entities\AccessToken', $accessToken);
+    $this->assertInstanceOf('Facebook\AccessToken', $accessToken);
     $this->assertEquals('id|secret', (string) $accessToken);
   }
 
@@ -60,7 +60,7 @@ class FacebookAppTest extends \PHPUnit_Framework_TestCase
   {
     $newApp = unserialize(serialize($this->app));
 
-    $this->assertInstanceOf('Facebook\Entities\FacebookApp', $newApp);
+    $this->assertInstanceOf('Facebook\FacebookApp', $newApp);
     $this->assertEquals('id', $newApp->getId());
     $this->assertEquals('secret', $newApp->getSecret());
   }

--- a/tests/FacebookBatchRequestTest.php
+++ b/tests/FacebookBatchRequestTest.php
@@ -21,12 +21,12 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Tests\Entities;
+namespace Facebook\Tests;
 
 use Facebook\Facebook;
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
-use Facebook\Entities\FacebookBatchRequest;
+use \Facebook\FacebookApp;
+use \Facebook\FacebookRequest;
+use \Facebook\FacebookBatchRequest;
 use Facebook\FileUpload\FacebookFile;
 
 class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
@@ -254,7 +254,7 @@ class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
   {
     $request = new FacebookRequest(null, null, 'POST', '/bar', [
         'message' => 'foobar',
-        'source' => new FacebookFile(__DIR__ . '/../foo.txt'),
+        'source' => new FacebookFile(__DIR__ . '/foo.txt'),
       ]);
 
     $batchRequest = $this->createBatchRequest();
@@ -306,7 +306,7 @@ class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
     $batchRequest->add(new FacebookRequest(null, 'bar_token', 'GET', '/foo'), 'foo_name');
     $batchRequest->add(new FacebookRequest(null, null, 'POST', '/me/photos', [
           'message' => 'foobar',
-          'source' => new FacebookFile(__DIR__ . '/../foo.txt'),
+          'source' => new FacebookFile(__DIR__ . '/foo.txt'),
         ]));
     $batchRequest->prepareRequestsForBatch();
 

--- a/tests/FacebookBatchResponseTest.php
+++ b/tests/FacebookBatchResponseTest.php
@@ -21,24 +21,24 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Tests\Entities;
+namespace Facebook\Tests;
 
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
-use Facebook\Entities\FacebookResponse;
-use Facebook\Entities\FacebookBatchRequest;
-use Facebook\Entities\FacebookBatchResponse;
+use Facebook\FacebookApp;
+use Facebook\FacebookRequest;
+use Facebook\FacebookResponse;
+use Facebook\FacebookBatchRequest;
+use Facebook\FacebookBatchResponse;
 
 class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
 {
 
   /**
-   * @var \Facebook\Entities\FacebookApp
+   * @var \Facebook\FacebookApp
    */
   protected $app;
 
   /**
-   * @var \Facebook\Entities\FacebookRequest
+   * @var \Facebook\FacebookRequest
    */
   protected $request;
 
@@ -108,7 +108,7 @@ class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
 
     foreach ($batchResponse as $key => $responseEntity) {
       $this->assertTrue(in_array($key, ['req_one', 'req_two', 'req_three']));
-      $this->assertInstanceOf('Facebook\Entities\FacebookResponse', $responseEntity);
+      $this->assertInstanceOf('Facebook\FacebookResponse', $responseEntity);
     }
   }
 
@@ -130,8 +130,8 @@ class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
     $batchRequest = new FacebookBatchRequest($this->app, $requests);
     $batchResponse = new FacebookBatchResponse($batchRequest, $response);
 
-    $this->assertInstanceOf('Facebook\Entities\FacebookResponse', $batchResponse[0]);
-    $this->assertInstanceOf('Facebook\Entities\FacebookRequest', $batchResponse[0]->getRequest());
+    $this->assertInstanceOf('Facebook\FacebookResponse', $batchResponse[0]);
+    $this->assertInstanceOf('Facebook\FacebookRequest', $batchResponse[0]->getRequest());
     $this->assertEquals('foo_token_one', $batchResponse[0]->getAccessToken());
     $this->assertEquals('foo_token_two', $batchResponse[1]->getAccessToken());
     $this->assertEquals('foo_token_three', $batchResponse[2]->getAccessToken());

--- a/tests/FacebookClientTest.php
+++ b/tests/FacebookClientTest.php
@@ -25,9 +25,9 @@ namespace Facebook\Tests;
 
 use Facebook\Exceptions\FacebookSDKException;
 use Facebook\Facebook;
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
-use Facebook\Entities\FacebookBatchRequest;
+use \Facebook\FacebookApp;
+use \Facebook\FacebookRequest;
+use \Facebook\FacebookBatchRequest;
 use Facebook\FacebookClient;
 use Facebook\Http\GraphRawResponse;
 use Facebook\HttpClients\FacebookHttpClientInterface;
@@ -148,7 +148,7 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
     $fbRequest = new FacebookRequest($this->fbApp, 'token', 'GET', '/foo');
     $response = $this->fbClient->sendRequest($fbRequest);
 
-    $this->assertInstanceOf('Facebook\Entities\FacebookResponse', $response);
+    $this->assertInstanceOf('Facebook\FacebookResponse', $response);
     $this->assertEquals(200, $response->getHttpStatusCode());
     $this->assertEquals('{"data":[{"id":"123","name":"Foo"},{"id":"1337","name":"Bar"}]}', $response->getBody());
   }
@@ -164,7 +164,7 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
     $fbBatchClient = new FacebookClient(new MyFooBatchClientHandler());
     $response = $fbBatchClient->sendBatchRequest($fbBatchRequest);
 
-    $this->assertInstanceOf('Facebook\Entities\FacebookBatchResponse', $response);
+    $this->assertInstanceOf('Facebook\FacebookBatchResponse', $response);
     $this->assertEquals('GET', $response[0]->getRequest()->getMethod());
     $this->assertEquals('POST', $response[1]->getRequest()->getMethod());
   }

--- a/tests/FacebookRequestTest.php
+++ b/tests/FacebookRequestTest.php
@@ -21,11 +21,11 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Tests\Entities;
+namespace Facebook\Tests;
 
 use Facebook\Facebook;
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
+use \Facebook\FacebookApp;
+use \Facebook\FacebookRequest;
 use Facebook\FileUpload\FacebookFile;
 use Facebook\FileUpload\FacebookVideo;
 
@@ -37,7 +37,7 @@ class FacebookRequestTest extends \PHPUnit_Framework_TestCase
     $app = new FacebookApp('123', 'foo_secret');
     $request = new FacebookRequest($app);
 
-    $this->assertInstanceOf('Facebook\Entities\FacebookRequest', $request);
+    $this->assertInstanceOf('Facebook\FacebookRequest', $request);
   }
 
   /**
@@ -172,7 +172,7 @@ class FacebookRequestTest extends \PHPUnit_Framework_TestCase
 
   public function testAFileCanBeAddedToParams()
   {
-    $myFile = new FacebookFile(__DIR__ . '/../foo.txt');
+    $myFile = new FacebookFile(__DIR__ . '/foo.txt');
     $params = [
       'name' => 'Foo Bar',
       'source' => $myFile,
@@ -190,7 +190,7 @@ class FacebookRequestTest extends \PHPUnit_Framework_TestCase
 
   public function testAVideoCanBeAddedToParams()
   {
-    $myFile = new FacebookVideo(__DIR__ . '/../foo.txt');
+    $myFile = new FacebookVideo(__DIR__ . '/foo.txt');
     $params = [
       'name' => 'Foo Bar',
       'source' => $myFile,

--- a/tests/FacebookResponseTest.php
+++ b/tests/FacebookResponseTest.php
@@ -21,17 +21,17 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Tests\Entities;
+namespace Facebook\Tests;
 
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
-use Facebook\Entities\FacebookResponse;
+use Facebook\FacebookApp;
+use Facebook\FacebookRequest;
+use Facebook\FacebookResponse;
 
 class FacebookResponseTest extends \PHPUnit_Framework_TestCase
 {
 
   /**
-   * @var \Facebook\Entities\FacebookRequest
+   * @var \Facebook\FacebookRequest
    */
   protected $request;
 

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -30,8 +30,8 @@ use Facebook\HttpClients\FacebookHttpClientInterface;
 use Facebook\PersistentData\PersistentDataInterface;
 use Facebook\Url\UrlDetectionInterface;
 use Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface;
-use Facebook\Entities\FacebookRequest;
-use Facebook\Entities\AccessToken;
+use \Facebook\FacebookRequest;
+use \Facebook\AccessToken;
 use Facebook\GraphNodes\GraphList;
 
 class FooClientInterface implements FacebookHttpClientInterface
@@ -177,7 +177,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
     $fb->setDefaultAccessToken('foo_token');
     $accessToken = $fb->getDefaultAccessToken();
 
-    $this->assertInstanceOf('Facebook\Entities\AccessToken', $accessToken);
+    $this->assertInstanceOf('Facebook\AccessToken', $accessToken);
     $this->assertEquals('foo_token', (string) $accessToken);
   }
 
@@ -187,7 +187,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
     $fb->setDefaultAccessToken(new AccessToken('bar_token'));
     $accessToken = $fb->getDefaultAccessToken();
 
-    $this->assertInstanceOf('Facebook\Entities\AccessToken', $accessToken);
+    $this->assertInstanceOf('Facebook\AccessToken', $accessToken);
     $this->assertEquals('bar_token', (string) $accessToken);
   }
 
@@ -336,7 +336,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
     $this->assertEquals('Foo', $nextPage[0]['name']);
 
     $lastResponse = $fb->getLastResponse();
-    $this->assertInstanceOf('Facebook\Entities\FacebookResponse', $lastResponse);
+    $this->assertInstanceOf('Facebook\FacebookResponse', $lastResponse);
     $this->assertEquals(1337, $lastResponse->getHttpStatusCode());
   }
 

--- a/tests/GraphNodes/GraphAlbumTest.php
+++ b/tests/GraphNodes/GraphAlbumTest.php
@@ -30,13 +30,13 @@ class GraphAlbumTest extends \PHPUnit_Framework_TestCase
 {
 
   /**
-   * @var \Facebook\Entities\FacebookResponse
+   * @var \Facebook\FacebookResponse
    */
   protected $responseMock;
 
   public function setUp()
   {
-    $this->responseMock = m::mock('\\Facebook\\Entities\\FacebookResponse');
+    $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
   }
 
   public function testDatesGetCastToDateTime()

--- a/tests/GraphNodes/GraphListTest.php
+++ b/tests/GraphNodes/GraphListTest.php
@@ -23,15 +23,15 @@
  */
 namespace Facebook\Tests\GraphNodes;
 
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
+use Facebook\FacebookApp;
+use Facebook\FacebookRequest;
 use Facebook\GraphNodes\GraphList;
 
 class GraphListTest extends \PHPUnit_Framework_TestCase
 {
 
   /**
-   * @var \Facebook\Entities\FacebookRequest
+   * @var \Facebook\FacebookRequest
    */
   protected $request;
 
@@ -106,8 +106,8 @@ class GraphListTest extends \PHPUnit_Framework_TestCase
     $nextPage = $graphList->getNextPageRequest();
     $prevPage = $graphList->getPreviousPageRequest();
 
-    $this->assertInstanceOf('Facebook\Entities\FacebookRequest', $nextPage);
-    $this->assertInstanceOf('Facebook\Entities\FacebookRequest', $prevPage);
+    $this->assertInstanceOf('Facebook\FacebookRequest', $nextPage);
+    $this->assertInstanceOf('Facebook\FacebookRequest', $prevPage);
     $this->assertNotSame($this->request, $nextPage);
     $this->assertNotSame($this->request, $prevPage);
     $this->assertEquals('/v1337/1234567890/likes?access_token=foo_token&after=bar_after_cursor&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&foo=bar&keep=me', $nextPage->getUrl());

--- a/tests/GraphNodes/GraphObjectFactoryTest.php
+++ b/tests/GraphNodes/GraphObjectFactoryTest.php
@@ -23,9 +23,9 @@
  */
 namespace Facebook\Tests\GraphNodes;
 
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\FacebookRequest;
-use Facebook\Entities\FacebookResponse;
+use Facebook\FacebookApp;
+use Facebook\FacebookRequest;
+use Facebook\FacebookResponse;
 use Facebook\GraphNodes\GraphObjectFactory;
 use Facebook\GraphNodes\GraphObject;
 
@@ -41,7 +41,7 @@ class GraphObjectFactoryTest extends \PHPUnit_Framework_TestCase
 {
 
   /**
-   * @var \Facebook\Entities\FacebookRequest
+   * @var \Facebook\FacebookRequest
    */
   protected $request;
 

--- a/tests/GraphNodes/GraphPageTest.php
+++ b/tests/GraphNodes/GraphPageTest.php
@@ -30,13 +30,13 @@ class GraphPageTest extends \PHPUnit_Framework_TestCase
 {
 
   /**
-   * @var \Facebook\Entities\FacebookResponse
+   * @var \Facebook\FacebookResponse
    */
   protected $responseMock;
 
   public function setUp()
   {
-    $this->responseMock = m::mock('\\Facebook\\Entities\\FacebookResponse');
+    $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
   }
 
   public function testPagePropertiesReturnGraphPageObjects()

--- a/tests/GraphNodes/GraphSessionInfoTest.php
+++ b/tests/GraphNodes/GraphSessionInfoTest.php
@@ -30,13 +30,13 @@ class GraphSessionInfoTest extends \PHPUnit_Framework_TestCase
 {
 
   /**
-   * @var \Facebook\Entities\FacebookResponse
+   * @var \Facebook\FacebookResponse
    */
   protected $responseMock;
 
   public function setUp()
   {
-    $this->responseMock = m::mock('\\Facebook\\Entities\\FacebookResponse');
+    $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
   }
 
   public function testDatesGetCastToDateTime()

--- a/tests/GraphNodes/GraphUserTest.php
+++ b/tests/GraphNodes/GraphUserTest.php
@@ -30,13 +30,13 @@ class GraphUserTest extends \PHPUnit_Framework_TestCase
 {
 
   /**
-   * @var \Facebook\Entities\FacebookResponse
+   * @var \Facebook\FacebookResponse
    */
   protected $responseMock;
 
   public function setUp()
   {
-    $this->responseMock = m::mock('\\Facebook\\Entities\\FacebookResponse');
+    $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
   }
 
   public function testDatesGetCastToDateTime()

--- a/tests/Helpers/FacebookCanvasHelperTest.php
+++ b/tests/Helpers/FacebookCanvasHelperTest.php
@@ -23,7 +23,7 @@
  */
 namespace Facebook\Tests\Helpers;
 
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 use Facebook\Helpers\FacebookCanvasHelper;
 
 class FacebookCanvasLoginHelperTest extends \PHPUnit_Framework_TestCase

--- a/tests/Helpers/FacebookJavaScriptHelperTest.php
+++ b/tests/Helpers/FacebookJavaScriptHelperTest.php
@@ -23,7 +23,7 @@
  */
 namespace Facebook\Tests\Helpers;
 
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 use Facebook\Helpers\FacebookJavaScriptHelper;
 
 class FacebookJavaScriptLoginHelperTest extends \PHPUnit_Framework_TestCase

--- a/tests/Helpers/FacebookPageTabHelperTest.php
+++ b/tests/Helpers/FacebookPageTabHelperTest.php
@@ -23,7 +23,7 @@
  */
 namespace Facebook\Tests\Helpers;
 
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 use Facebook\Helpers\FacebookPageTabHelper;
 
 class FacebookPageTabHelperTest extends \PHPUnit_Framework_TestCase

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -25,7 +25,7 @@ namespace Facebook\Tests\Helpers;
 
 use Mockery as m;
 use Facebook\Facebook;
-use Facebook\Entities\FacebookApp;
+use \Facebook\FacebookApp;
 use Facebook\Helpers\FacebookRedirectLoginHelper;
 use Facebook\PersistentData\FacebookMemoryPersistentDataHandler;
 use Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface;
@@ -101,7 +101,7 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
     $_GET['state'] = 'foo_state';
     $_GET['code'] = 'foo_code';
 
-    $response = m::mock('Facebook\Entities\FacebookResponse');
+    $response = m::mock('Facebook\FacebookResponse');
     $response
       ->shouldReceive('getDecodedBody')
       ->once()
@@ -112,7 +112,7 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
     $client = m::mock('Facebook\FacebookClient');
     $client
       ->shouldReceive('sendRequest')
-      ->with(m::type('Facebook\Entities\FacebookRequest'))
+      ->with(m::type('Facebook\FacebookRequest'))
       ->once()
       ->andReturn($response);
 
@@ -121,7 +121,7 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
 
     $accessToken = $helper->getAccessToken($client, self::REDIRECT_URL);
 
-    $this->assertInstanceOf('Facebook\Entities\AccessToken', $accessToken);
+    $this->assertInstanceOf('Facebook\AccessToken', $accessToken);
     $this->assertEquals('access_token_from_code', (string) $accessToken);
   }
   

--- a/tests/Helpers/FacebookSignedRequestFromInputHelperTest.php
+++ b/tests/Helpers/FacebookSignedRequestFromInputHelperTest.php
@@ -24,7 +24,7 @@
 namespace Facebook\Tests\Helpers;
 
 use Mockery as m;
-use Facebook\Entities\FacebookApp;
+use Facebook\FacebookApp;
 use Facebook\Helpers\FacebookSignedRequestFromInputHelper;
 
 class FooSignedRequestHelper extends FacebookSignedRequestFromInputHelper {
@@ -101,13 +101,13 @@ class FacebookSignedRequestFromInputHelperTest extends \PHPUnit_Framework_TestCa
     $this->helper->instantiateSignedRequest($this->rawSignedRequestAuthorizedWithAccessToken);
     $accessToken = $this->helper->getAccessToken($client);
 
-    $this->assertInstanceOf('Facebook\Entities\AccessToken', $accessToken);
+    $this->assertInstanceOf('Facebook\AccessToken', $accessToken);
     $this->assertEquals('foo_token', (string) $accessToken);
   }
 
   public function testAnAccessTokenCanBeInstantiatedWhenRedirectReturnsACode()
   {
-    $response = m::mock('Facebook\Entities\FacebookResponse');
+    $response = m::mock('Facebook\FacebookResponse');
     $response
       ->shouldReceive('getDecodedBody')
       ->once()
@@ -118,14 +118,14 @@ class FacebookSignedRequestFromInputHelperTest extends \PHPUnit_Framework_TestCa
     $client = m::mock('Facebook\FacebookClient');
     $client
       ->shouldReceive('sendRequest')
-      ->with(m::type('Facebook\Entities\FacebookRequest'))
+      ->with(m::type('Facebook\FacebookRequest'))
       ->once()
       ->andReturn($response);
 
     $this->helper->instantiateSignedRequest($this->rawSignedRequestAuthorizedWithCode);
     $accessToken = $this->helper->getAccessToken($client);
 
-    $this->assertInstanceOf('Facebook\Entities\AccessToken', $accessToken);
+    $this->assertInstanceOf('Facebook\AccessToken', $accessToken);
     $this->assertEquals('access_token_from_code', (string) $accessToken);
   }
 

--- a/tests/SignedRequestTest.php
+++ b/tests/SignedRequestTest.php
@@ -21,10 +21,10 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\Tests\Entities;
+namespace Facebook\Tests;
 
-use Facebook\Entities\FacebookApp;
-use Facebook\Entities\SignedRequest;
+use Facebook\FacebookApp;
+use Facebook\SignedRequest;
 
 class SignedRequestTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This knocks out BC number 2 in #290.

Dear people who use the master branch, this this will break all the things - sorry! But all you have to do is remove any reference to `Entities/`. For example `Facebook/Entities/FacebookApp` is now just `Facebook/FacebookApp`. A quick search/replace should do the trick!

This kinda looks like a big PR - but I just used phpStorm to refactor the location of the `Entities/*` files and it did all the work. It even updated the docs automatically! Man, phpStorm is pretty amazing really!
