### PR TITLE
Added CSRF protection for rerequest links

### DIFF
--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -121,9 +121,12 @@ class FacebookRedirectLoginHelper
   public function getReRequestUrl($scope = array(), $version = null)
   {
     $version = ($version ?: FacebookRequest::GRAPH_API_VERSION);
+    $this->state = $this->random(16);
+    $this->storeState($this->state);
     $params = array(
       'client_id' => $this->appId,
       'redirect_uri' => $this->redirectUrl,
+      'state' => $this->state,
       'sdk' => 'php-sdk-' . FacebookRequest::VERSION,
       'auth_type' => 'rerequest',
       'scope' => implode(',', $scope)

--- a/tests/FacebookRedirectLoginHelperTest.php
+++ b/tests/FacebookRedirectLoginHelperTest.php
@@ -32,6 +32,21 @@ class FacebookRedirectLoginHelperTest extends PHPUnit_Framework_TestCase
     }
   }
 
+  public function testReRequestUrlContainsState()
+  {
+    $helper = new FacebookRedirectLoginHelper(
+      self::REDIRECT_URL,
+      FacebookTestCredentials::$appId,
+      FacebookTestCredentials::$appSecret
+    );
+    $helper->disableSessionStatusCheck();
+
+    $reRequestUrl = $helper->getReRequestUrl();
+    $state = $_SESSION['FBRLH_state'];
+
+    $this->assertContains('state=' . urlencode($state), $reRequestUrl);
+  }
+
   public function testLogoutURL()
   {
     $helper = new FacebookRedirectLoginHelper(


### PR DESCRIPTION
Quick fix for #249.

This issue doesn't exist in 4.1.
