### PR TITLE
Allow HHVM failures in TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
   include:
     - php: hhvm
       dist: trusty
+  allow_failures:
+    - php: hhvm
 
 before_install:
   - travis_retry composer self-update


### PR DESCRIPTION
Per [the discussion on the topic](https://github.com/facebook/php-graph-sdk/pull/854#issuecomment-401978940). We can always revert this later on if Facebook wants to jump in and maintain HHVM support. :)