### PR TITLE
Conserve id when next to data key, resolves #700

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Version 5 of the Facebook PHP SDK is a complete refactor of version 4. It comes 
   - Fixed HTTP/2 support (#1079)
   - Fixed resumable upload error (#1001)
   - Strip 'enforce_https' param (#1084)
+  - Conserve id when next to data key, resolves #700 (#1034)
 - 5.6.3 (2018-07-01)
   - Add fix for countable error in PHP 7.2 (originally #969 by @andreybolonin)
 - 5.6.2 (2018-02-15)

--- a/src/Facebook/GraphNodes/GraphNodeFactory.php
+++ b/src/Facebook/GraphNodes/GraphNodeFactory.php
@@ -304,7 +304,9 @@ class GraphNodeFactory
                 return $this->safelyMakeGraphEdge($data, $subclassName, $parentKey, $parentNodeId);
             }
             // Sometimes Graph is a weirdo and returns a GraphNode under the "data" key
-            $data = $data['data'];
+            $outerData = $data;
+            unset($outerData['data']);
+            $data = $data['data'] + $outerData;
         }
 
         // Create GraphNode

--- a/tests/GraphNodes/GraphNodeFactoryTest.php
+++ b/tests/GraphNodes/GraphNodeFactoryTest.php
@@ -247,6 +247,33 @@ class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
         ], $graphData);
     }
 
+    public function testAGraphNodeWithARootDataKeyWillConserveRootKeys()
+    {
+        $data = json_encode([
+            'id' => '123',
+            'foo' => 'bar',
+            'data' => [
+                'name' => 'Foo McBar',
+                'link' => 'http://facebook/foo',
+            ],
+        ]);
+
+        $res = new FacebookResponse($this->request, $data);
+        $factory = new GraphNodeFactory($res);
+        $graphNode = $factory->makeGraphNode();
+
+        $this->assertInstanceOf('\Facebook\GraphNodes\GraphNode', $graphNode);
+
+        $graphData = $graphNode->asArray();
+
+        $this->assertEquals([
+            'id' => '123',
+            'foo' => 'bar',
+            'name' => 'Foo McBar',
+            'link' => 'http://facebook/foo',
+        ], $graphData);
+    }
+
     public function testAGraphEdgeWillBeCastRecursively()
     {
         $someUser = [


### PR DESCRIPTION
closes #700, closes #1010

#700 is still consistently a problem across all versions of the Graph API.