### PR TITLE
Add some fields to automatic cast to DateTime

### DIFF
--- a/src/Facebook/GraphNodes/GraphNode.php
+++ b/src/Facebook/GraphNodes/GraphNode.php
@@ -151,7 +151,12 @@ class GraphNode extends Collection
             'issued_at',
             'expires_at',
             'publish_time',
-            'joined'
+            'joined',
+            'left_time',
+            'seen_time',
+            'start_date',
+            'account_invite_time',
+            'account_claim_time'
         ], true);
     }
 


### PR DESCRIPTION
I add 5 fields because they exists on Workplace by Facebook GraphAPI 
https://developers.facebook.com/docs/workplace/reference/graph-api/member
left_time is for /{group_id}/former_members