### PR TITLE
[6.0] Update PHPUnit to version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php-http/message": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.2",
+        "phpunit/phpunit": "^7.5",
         "php-http/guzzle6-adapter": "^1.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
         convertWarningsToExceptions="true"
         stopOnFailure="false"
         bootstrap="tests/bootstrap.php"
+        backupGlobals="true"
         verbose="true">
     <testsuites>
         <testsuite name="Facebook PHP SDK Test Suite">

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -33,8 +33,9 @@ class ApplicationTest extends TestCase
      */
     private $app;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->app = new Application('id', 'secret');
     }
 

--- a/tests/Authentication/OAuth2ClientTest.php
+++ b/tests/Authentication/OAuth2ClientTest.php
@@ -47,8 +47,10 @@ class OAuth2ClientTest extends TestCase
      */
     protected $oauth;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $app = new Application('123', 'foo_secret');
         $this->client = new FooClientForOAuth2Test();
         $this->oauth = new OAuth2Client($app, $this->client, static::TESTING_GRAPH_VERSION);

--- a/tests/BatchRequestTest.php
+++ b/tests/BatchRequestTest.php
@@ -35,8 +35,10 @@ class BatchRequestTest extends TestCase
      */
     private $app;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->app = new Application('123', 'foo_secret');
     }
 

--- a/tests/BatchResponseTest.php
+++ b/tests/BatchResponseTest.php
@@ -42,8 +42,9 @@ class BatchResponseTest extends TestCase
      */
     protected $request;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->app = new Application('123', 'foo_secret');
         $this->request = new Request(
             $this->app,

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -60,8 +60,10 @@ class ClientTest extends TestCase
      */
     public static $testClient;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->fbApp = new Application('id', 'shhhh!');
         $this->fbClient = new Client(new MyFooHttpClient());
     }

--- a/tests/Exception/ResponseExceptionTest.php
+++ b/tests/Exception/ResponseExceptionTest.php
@@ -42,8 +42,10 @@ class ResponseExceptionTest extends TestCase
      */
     protected $request;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->request = new Request(new Application('123', 'foo'));
     }
 

--- a/tests/FileUpload/FileTest.php
+++ b/tests/FileUpload/FileTest.php
@@ -29,8 +29,9 @@ class FileTest extends TestCase
 {
     protected $testFile = '';
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->testFile = __DIR__ . '/../foo.txt';
     }
 

--- a/tests/FileUpload/ResumableUploaderTest.php
+++ b/tests/FileUpload/ResumableUploaderTest.php
@@ -53,8 +53,10 @@ class ResumableUploaderTest extends TestCase
      */
     private $file;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->fbApp = new Application('app_id', 'app_secret');
         $this->graphApi = new FakeGraphApiForResumableUpload();
         $this->client = new Client($this->graphApi);

--- a/tests/GraphNode/AbstractGraphNode.php
+++ b/tests/GraphNode/AbstractGraphNode.php
@@ -34,7 +34,7 @@ abstract class AbstractGraphNode extends TestCase
      */
     protected $responseMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/GraphNode/GraphAlbumTest.php
+++ b/tests/GraphNode/GraphAlbumTest.php
@@ -37,8 +37,10 @@ class GraphAlbumTest extends TestCase
      */
     protected $responseMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->responseMock = $this->prophesize(Response::class);
     }
 

--- a/tests/GraphNode/GraphEdgeTest.php
+++ b/tests/GraphNode/GraphEdgeTest.php
@@ -41,8 +41,10 @@ class GraphEdgeTest extends TestCase
         'previous' => 'https://graph.facebook.com/v7.12/998899/photos?pretty=0&limit=25&before=foo_before_cursor',
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $app = new Application('123', 'foo_app_secret');
         $this->request = new Request(
             $app,

--- a/tests/GraphNode/GraphEventTest.php
+++ b/tests/GraphNode/GraphEventTest.php
@@ -38,8 +38,10 @@ class GraphEventTest extends TestCase
      */
     protected $responseMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->responseMock = $this->prophesize(Response::class);
     }
 

--- a/tests/GraphNode/GraphGroupTest.php
+++ b/tests/GraphNode/GraphGroupTest.php
@@ -36,8 +36,9 @@ class GraphGroupTest extends TestCase
      */
     protected $responseMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->responseMock = $this->prophesize(Response::class);
     }
 

--- a/tests/GraphNode/GraphNodeFactoryTest.php
+++ b/tests/GraphNode/GraphNodeFactoryTest.php
@@ -40,8 +40,10 @@ class GraphNodeFactoryTest extends TestCase
      */
     protected $request;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $app = new Application('123', 'foo_app_secret');
         $this->request = new Request(
             $app,

--- a/tests/GraphNode/GraphPageTest.php
+++ b/tests/GraphNode/GraphPageTest.php
@@ -36,8 +36,10 @@ class GraphPageTest extends TestCase
      */
     protected $responseMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->responseMock = $this->prophesize(Response::class);
     }
 

--- a/tests/GraphNode/GraphSessionInfoTest.php
+++ b/tests/GraphNode/GraphSessionInfoTest.php
@@ -34,8 +34,9 @@ class GraphSessionInfoTest extends TestCase
      */
     protected $responseMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->responseMock = $this->prophesize(Response::class);
     }
 

--- a/tests/GraphNode/GraphUserTest.php
+++ b/tests/GraphNode/GraphUserTest.php
@@ -38,8 +38,10 @@ class GraphUserTest extends TestCase
      */
     protected $responseMock;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->responseMock = $this->prophesize(Response::class);
     }
 

--- a/tests/Helper/CanvasHelperTest.php
+++ b/tests/Helper/CanvasHelperTest.php
@@ -36,8 +36,9 @@ class CanvasHelperTest extends TestCase
      */
     protected $helper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $app = new Application('123', 'foo_app_secret');
         $this->helper = new CanvasHelper($app, new Client(), 'v0.0');
     }

--- a/tests/Helper/RedirectLoginHelperTest.php
+++ b/tests/Helper/RedirectLoginHelperTest.php
@@ -44,8 +44,10 @@ class RedirectLoginHelperTest extends TestCase
 
     const REDIRECT_URL = 'http://invalid.zzz';
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->persistentDataHandler = new InMemoryPersistentDataHandler();
 
         $app = new Application('123', 'foo_app_secret');

--- a/tests/Helper/SignedRequestFromInputHelperTest.php
+++ b/tests/Helper/SignedRequestFromInputHelperTest.php
@@ -39,8 +39,10 @@ class SignedRequestFromInputHelperTest extends TestCase
     public $rawSignedRequestAuthorizedWithCode = 'oBtmZlsFguNQvGRETDYQQu1-PhwcArgbBBEK4urbpRA=.eyJjb2RlIjoiZm9vX2NvZGUiLCJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsImlzc3VlZF9hdCI6MTQwNjMxMDc1MiwidXNlcl9pZCI6IjEyMyJ9';
     public $rawSignedRequestUnauthorized = 'KPlyhz-whtYAhHWr15N5TkbS_avz-2rUJFpFkfXKC88=.eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsImlzc3VlZF9hdCI6MTQwMjU1MTA4Nn0=';
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $app = new Application('123', 'foo_app_secret');
         $this->helper = new FooSignedRequestHelper($app, new FooSignedRequestHelperClient(), 'v0.0');
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -36,8 +36,10 @@ class ResponseTest extends TestCase
      */
     protected $request;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $app = new Application('123', 'foo_secret');
         $this->request = new Request(
             $app,

--- a/tests/SignedRequestTest.php
+++ b/tests/SignedRequestTest.php
@@ -46,8 +46,10 @@ class SignedRequestTest extends TestCase
         'foo' => 'bar',
     ];
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
+
         $this->app = new Application('123', 'foo_app_secret');
     }
 


### PR DESCRIPTION
Marked ``setUp()`` functions as ``void`` for future proofing an update to PHPUnit version 8.