### PR TITLE
Add JSON extension as a required dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require": {
         "php": "^7.1",
+        "ext-json": "*",
         "psr/http-message": "^1.0",
         "php-http/client-implementation": "^1.0",
         "php-http/httplug": "^1.0",


### PR DESCRIPTION
JSON extension is being used but not explicitly reinquired as a dependency.