### PR TITLE
[6.0] Add type hints to code base.

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -43,7 +43,7 @@ class Application implements \Serializable
      *
      * @throws SDKException
      */
-    public function __construct($id, $secret)
+    public function __construct(string $id, string $secret)
     {
         if (!is_string($id)
           // Keeping this for BC. Integers greater than PHP_INT_MAX will make is_int() return false
@@ -60,7 +60,7 @@ class Application implements \Serializable
      *
      * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
@@ -70,7 +70,7 @@ class Application implements \Serializable
      *
      * @return string
      */
-    public function getSecret()
+    public function getSecret(): string
     {
         return $this->secret;
     }
@@ -80,7 +80,7 @@ class Application implements \Serializable
      *
      * @return AccessToken
      */
-    public function getAccessToken()
+    public function getAccessToken(): AccessToken
     {
         return new AccessToken($this->id . '|' . $this->secret);
     }
@@ -90,7 +90,7 @@ class Application implements \Serializable
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): string
     {
         return implode('|', [$this->id, $this->secret]);
     }
@@ -100,7 +100,7 @@ class Application implements \Serializable
      *
      * @param string $serialized
      */
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
         list($id, $secret) = explode('|', $serialized);
 

--- a/src/Authentication/AccessToken.php
+++ b/src/Authentication/AccessToken.php
@@ -47,7 +47,7 @@ class AccessToken
      * @param string $accessToken
      * @param int    $expiresAt
      */
-    public function __construct($accessToken, $expiresAt = 0)
+    public function __construct(string $accessToken, int $expiresAt = 0)
     {
         $this->value = $accessToken;
         if ($expiresAt) {
@@ -62,7 +62,7 @@ class AccessToken
      *
      * @return string
      */
-    public function getAppSecretProof($appSecret)
+    public function getAppSecretProof(string $appSecret): string
     {
         return hash_hmac('sha256', $this->value, $appSecret);
     }
@@ -72,7 +72,7 @@ class AccessToken
      *
      * @return null|\DateTime
      */
-    public function getExpiresAt()
+    public function getExpiresAt(): ?\DateTime
     {
         return $this->expiresAt;
     }
@@ -82,7 +82,7 @@ class AccessToken
      *
      * @return bool
      */
-    public function isAppAccessToken()
+    public function isAppAccessToken(): bool
     {
         return strpos($this->value, '|') !== false;
     }
@@ -92,7 +92,7 @@ class AccessToken
      *
      * @return bool
      */
-    public function isLongLived()
+    public function isLongLived(): bool
     {
         if ($this->expiresAt) {
             return $this->expiresAt->getTimestamp() > time() + (60 * 60 * 2);
@@ -106,7 +106,7 @@ class AccessToken
      *
      * @return null|bool
      */
-    public function isExpired()
+    public function isExpired() : ?bool
     {
         if ($this->getExpiresAt() instanceof \DateTime) {
             return $this->getExpiresAt()->getTimestamp() < time();
@@ -124,7 +124,7 @@ class AccessToken
      *
      * @return string
      */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }
@@ -134,7 +134,7 @@ class AccessToken
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getValue();
     }
@@ -144,7 +144,7 @@ class AccessToken
      *
      * @param int $timeStamp
      */
-    protected function setExpiresAtFromTimeStamp($timeStamp)
+    protected function setExpiresAtFromTimeStamp(int $timeStamp): void
     {
         $dt = new \DateTime();
         $dt->setTimestamp($timeStamp);

--- a/src/Authentication/AccessTokenMetadata.php
+++ b/src/Authentication/AccessTokenMetadata.php
@@ -71,7 +71,7 @@ class AccessTokenMetadata
      *
      * @return mixed
      */
-    public function getField($field, $default = null)
+    public function getField(string $field, $default = null)
     {
         if (isset($this->metadata[$field])) {
             return $this->metadata[$field];
@@ -89,7 +89,7 @@ class AccessTokenMetadata
      *
      * @return mixed
      */
-    public function getChildProperty($parentField, $field, $default = null)
+    public function getChildProperty(string $parentField, string $field, $default = null)
     {
         if (!isset($this->metadata[$parentField])) {
             return $default;
@@ -110,7 +110,7 @@ class AccessTokenMetadata
      *
      * @return mixed
      */
-    public function getErrorProperty($field, $default = null)
+    public function getErrorProperty(string $field, $default = null)
     {
         return $this->getChildProperty('error', $field, $default);
     }
@@ -123,7 +123,7 @@ class AccessTokenMetadata
      *
      * @return mixed
      */
-    public function getMetadataProperty($field, $default = null)
+    public function getMetadataProperty(string $field, $default = null)
     {
         return $this->getChildProperty('metadata', $field, $default);
     }
@@ -133,7 +133,7 @@ class AccessTokenMetadata
      *
      * @return null|string
      */
-    public function getAppId()
+    public function getAppId(): ?string
     {
         return $this->getField('app_id');
     }
@@ -143,7 +143,7 @@ class AccessTokenMetadata
      *
      * @return null|string
      */
-    public function getApplication()
+    public function getApplication(): ?string
     {
         return $this->getField('application');
     }
@@ -154,7 +154,7 @@ class AccessTokenMetadata
      *
      * @return null|bool
      */
-    public function isError()
+    public function isError(): ?bool
     {
         return $this->getField('error') !== null;
     }
@@ -164,7 +164,7 @@ class AccessTokenMetadata
      *
      * @return null|int
      */
-    public function getErrorCode()
+    public function getErrorCode(): ?int
     {
         return $this->getErrorProperty('code');
     }
@@ -174,7 +174,7 @@ class AccessTokenMetadata
      *
      * @return null|string
      */
-    public function getErrorMessage()
+    public function getErrorMessage(): ?string
     {
         return $this->getErrorProperty('message');
     }
@@ -184,7 +184,7 @@ class AccessTokenMetadata
      *
      * @return null|int
      */
-    public function getErrorSubcode()
+    public function getErrorSubcode(): ?int
     {
         return $this->getErrorProperty('subcode');
     }
@@ -194,7 +194,7 @@ class AccessTokenMetadata
      *
      * @return null|\DateTime
      */
-    public function getExpiresAt()
+    public function getExpiresAt(): ?\DateTime
     {
         return $this->getField('expires_at');
     }
@@ -204,7 +204,7 @@ class AccessTokenMetadata
      *
      * @return null|bool
      */
-    public function getIsValid()
+    public function getIsValid(): ?bool
     {
         return $this->getField('is_valid');
     }
@@ -219,7 +219,7 @@ class AccessTokenMetadata
      *
      * @return null|\DateTime
      */
-    public function getIssuedAt()
+    public function getIssuedAt(): ?\DateTime
     {
         return $this->getField('issued_at');
     }
@@ -230,7 +230,7 @@ class AccessTokenMetadata
      *
      * @return null|array
      */
-    public function getMetadata()
+    public function getMetadata(): ?array
     {
         return $this->getField('metadata');
     }
@@ -240,7 +240,7 @@ class AccessTokenMetadata
      *
      * @return null|string
      */
-    public function getSso()
+    public function getSso(): ?string
     {
         return $this->getMetadataProperty('sso');
     }
@@ -250,7 +250,7 @@ class AccessTokenMetadata
      *
      * @return null|string
      */
-    public function getAuthType()
+    public function getAuthType(): ?string
     {
         return $this->getMetadataProperty('auth_type');
     }
@@ -260,7 +260,7 @@ class AccessTokenMetadata
      *
      * @return null|string
      */
-    public function getAuthNonce()
+    public function getAuthNonce(): ?string
     {
         return $this->getMetadataProperty('auth_nonce');
     }
@@ -271,7 +271,7 @@ class AccessTokenMetadata
      *
      * @return null|string
      */
-    public function getProfileId()
+    public function getProfileId(): ?string
     {
         return $this->getField('profile_id');
     }
@@ -282,7 +282,7 @@ class AccessTokenMetadata
      *
      * @return array
      */
-    public function getScopes()
+    public function getScopes(): array
     {
         return $this->getField('scopes');
     }
@@ -292,7 +292,7 @@ class AccessTokenMetadata
      *
      * @return null|string
      */
-    public function getUserId()
+    public function getUserId(): ?string
     {
         return $this->getField('user_id');
     }
@@ -305,7 +305,7 @@ class AccessTokenMetadata
      *
      * @throws SDKException
      */
-    public function validateAppId($appId)
+    public function validateAppId(string $appId): void
     {
         if ($this->getAppId() !== $appId) {
             throw new SDKException('Access token metadata contains unexpected app ID.', 401);
@@ -320,7 +320,7 @@ class AccessTokenMetadata
      *
      * @throws SDKException
      */
-    public function validateUserId($userId)
+    public function validateUserId(string $userId): void
     {
         if ($this->getUserId() !== $userId) {
             throw new SDKException('Access token metadata contains unexpected user ID.', 401);
@@ -332,7 +332,7 @@ class AccessTokenMetadata
      *
      * @throws SDKException
      */
-    public function validateExpiration()
+    public function validateExpiration(): void
     {
         if (!$this->getExpiresAt() instanceof \DateTime) {
             return;
@@ -350,7 +350,7 @@ class AccessTokenMetadata
      *
      * @return \DateTime
      */
-    private function convertTimestampToDateTime($timestamp)
+    private function convertTimestampToDateTime(int $timestamp): \DateTime
     {
         $dt = new \DateTime();
         $dt->setTimestamp($timestamp);
@@ -361,7 +361,7 @@ class AccessTokenMetadata
     /**
      * Casts the unix timestamps as DateTime entities.
      */
-    private function castTimestampsToDateTime()
+    private function castTimestampsToDateTime(): void
     {
         foreach (static::$dateProperties as $key) {
             if (isset($this->metadata[$key]) && $this->metadata[$key] !== 0) {

--- a/src/Authentication/OAuth2Client.php
+++ b/src/Authentication/OAuth2Client.php
@@ -73,7 +73,7 @@ class OAuth2Client
      * @param Client      $client
      * @param string      $graphVersion the version of the Graph API to use
      */
-    public function __construct(Application $app, Client $client, $graphVersion)
+    public function __construct(Application $app, Client $client, string $graphVersion)
     {
         $this->app = $app;
         $this->client = $client;
@@ -86,7 +86,7 @@ class OAuth2Client
      *
      * @return null|Request
      */
-    public function getLastRequest()
+    public function getLastRequest(): ?Request
     {
         return $this->lastRequest;
     }
@@ -98,7 +98,7 @@ class OAuth2Client
      *
      * @return AccessTokenMetadata
      */
-    public function debugToken($accessToken)
+    public function debugToken($accessToken): AccessTokenMetadata
     {
         $accessToken = $accessToken instanceof AccessToken ? $accessToken->getValue() : $accessToken;
         $params = ['input_token' => $accessToken];
@@ -109,7 +109,7 @@ class OAuth2Client
             'GET',
             '/debug_token',
             $params,
-            null,
+            '',
             $this->graphVersion
         );
         $response = $this->client->sendRequest($this->lastRequest);
@@ -129,8 +129,13 @@ class OAuth2Client
      *
      * @return string
      */
-    public function getAuthorizationUrl($redirectUrl, $state, array $scope = [], array $params = [], $separator = '&')
-    {
+    public function getAuthorizationUrl(
+        string $redirectUrl,
+        string $state,
+        array $scope = [],
+        array $params = [],
+        string $separator = '&'
+    ): string {
         $params += [
             'client_id' => $this->app->getId(),
             'state' => $state,
@@ -153,7 +158,7 @@ class OAuth2Client
      *
      * @return AccessToken
      */
-    public function getAccessTokenFromCode($code, $redirectUri = '')
+    public function getAccessTokenFromCode(string $code, string $redirectUri = '')
     {
         $params = [
             'code' => $code,
@@ -172,7 +177,7 @@ class OAuth2Client
      *
      * @return AccessToken
      */
-    public function getLongLivedAccessToken($accessToken)
+    public function getLongLivedAccessToken($accessToken): AccessToken
     {
         $accessToken = $accessToken instanceof AccessToken ? $accessToken->getValue() : $accessToken;
         $params = [
@@ -191,9 +196,9 @@ class OAuth2Client
      *
      * @throws SDKException
      *
-     * @return AccessToken
+     * @return string
      */
-    public function getCodeFromLongLivedAccessToken($accessToken, $redirectUri = '')
+    public function getCodeFromLongLivedAccessToken($accessToken, string $redirectUri = ''): string
     {
         $params = [
             'redirect_uri' => $redirectUri,
@@ -218,7 +223,7 @@ class OAuth2Client
      *
      * @return AccessToken
      */
-    protected function requestAnAccessToken(array $params)
+    protected function requestAnAccessToken(array $params): AccessToken
     {
         $response = $this->sendRequestWithClientParams('/oauth/access_token', $params);
         $data = $response->getDecodedBody();
@@ -255,7 +260,7 @@ class OAuth2Client
      *
      * @return Response
      */
-    protected function sendRequestWithClientParams($endpoint, array $params, $accessToken = null)
+    protected function sendRequestWithClientParams(string $endpoint, array $params, $accessToken = null): Response
     {
         $params += $this->getClientParams();
 
@@ -267,7 +272,7 @@ class OAuth2Client
             'GET',
             $endpoint,
             $params,
-            null,
+            '',
             $this->graphVersion
         );
 
@@ -279,7 +284,7 @@ class OAuth2Client
      *
      * @return array
      */
-    protected function getClientParams()
+    protected function getClientParams(): array
     {
         return [
             'client_id' => $this->app->getId(),

--- a/src/BatchRequest.php
+++ b/src/BatchRequest.php
@@ -54,7 +54,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
     public function __construct(
         ?Application $app = null,
         array $requests = [],
-        ?string $accessToken = null,
+        $accessToken = null,
         ?string $graphVersion = null
     ) {
         parent::__construct($app, $accessToken, 'POST', '', [], '', $graphVersion);

--- a/src/BatchRequest.php
+++ b/src/BatchRequest.php
@@ -51,9 +51,13 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
      * @param null|AccessToken|string $accessToken
      * @param null|string             $graphVersion
      */
-    public function __construct(Application $app = null, array $requests = [], $accessToken = null, $graphVersion = null)
-    {
-        parent::__construct($app, $accessToken, 'POST', '', [], null, $graphVersion);
+    public function __construct(
+        ?Application $app = null,
+        array $requests = [],
+        ?string $accessToken = null,
+        ?string $graphVersion = null
+    ) {
+        parent::__construct($app, $accessToken, 'POST', '', [], '', $graphVersion);
 
         $this->add($requests);
     }
@@ -68,9 +72,8 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
      * @throws \InvalidArgumentException
      *
      * @return BatchRequest
-     * @return BatchRequest
      */
-    public function add($request, $options = null)
+    public function add($request, $options = null): BatchRequest
     {
         if (is_array($request)) {
             foreach ($request as $key => $req) {
@@ -118,7 +121,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
      *
      * @throws SDKException
      */
-    public function addFallbackDefaults(Request $request)
+    public function addFallbackDefaults(Request $request): void
     {
         if (!$request->getApplication()) {
             $app = $this->getApplication();
@@ -146,7 +149,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
      *
      * @return null|string
      */
-    public function extractFileAttachments(Request $request)
+    public function extractFileAttachments(Request $request): ?string
     {
         if (!$request->containsFileUploads()) {
             return null;
@@ -171,7 +174,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
      *
      * @return array
      */
-    public function getRequests()
+    public function getRequests(): array
     {
         return $this->requests;
     }
@@ -179,7 +182,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
     /**
      * Prepares the requests to be sent as a batch request.
      */
-    public function prepareRequestsForBatch()
+    public function prepareRequestsForBatch(): void
     {
         $this->validateBatchRequestCount();
 
@@ -195,7 +198,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
      *
      * @return string
      */
-    public function convertRequestsToJson()
+    public function convertRequestsToJson(): string
     {
         $requests = [];
         foreach ($this->requests as $request) {
@@ -218,7 +221,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
      *
      * @throws SDKException
      */
-    public function validateBatchRequestCount()
+    public function validateBatchRequestCount(): void
     {
         $batchCount = count($this->requests);
         if ($batchCount === 0) {
@@ -239,7 +242,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
      *
      * @return array
      */
-    public function requestEntityToBatchArray(Request $request, $options = null, $attachedFiles = null)
+    public function requestEntityToBatchArray(Request $request, $options = null, ?string $attachedFiles = null): array
     {
 
         if (null === $options) {
@@ -281,7 +284,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
      *
      * @return ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->requests);
     }
@@ -289,7 +292,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->add($value, $offset);
     }
@@ -297,7 +300,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->requests[$offset]);
     }
@@ -305,7 +308,7 @@ class BatchRequest extends Request implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->requests[$offset]);
     }

--- a/src/BatchResponse.php
+++ b/src/BatchResponse.php
@@ -66,7 +66,7 @@ class BatchResponse extends Response implements IteratorAggregate, ArrayAccess
      *
      * @return Response[]
      */
-    public function getResponses()
+    public function getResponses(): array
     {
         return $this->responses;
     }
@@ -77,7 +77,7 @@ class BatchResponse extends Response implements IteratorAggregate, ArrayAccess
      *
      * @param array $responses
      */
-    public function setResponses(array $responses)
+    public function setResponses(array $responses): void
     {
         $this->responses = [];
 
@@ -92,7 +92,7 @@ class BatchResponse extends Response implements IteratorAggregate, ArrayAccess
      * @param int        $key
      * @param null|array $response
      */
-    public function addResponse($key, $response)
+    public function addResponse(int $key, ?array $response): void
     {
         $originalRequestName = $this->batchRequest[$key]['name'] ?? $key;
         $originalRequest = $this->batchRequest[$key]['request'] ?? null;
@@ -113,7 +113,7 @@ class BatchResponse extends Response implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->responses);
     }
@@ -121,7 +121,7 @@ class BatchResponse extends Response implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->addResponse($offset, $value);
     }
@@ -129,7 +129,7 @@ class BatchResponse extends Response implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->responses[$offset]);
     }
@@ -137,7 +137,7 @@ class BatchResponse extends Response implements IteratorAggregate, ArrayAccess
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->responses[$offset]);
     }
@@ -159,7 +159,7 @@ class BatchResponse extends Response implements IteratorAggregate, ArrayAccess
      *
      * @return array
      */
-    private function normalizeBatchHeaders(array $batchHeaders)
+    private function normalizeBatchHeaders(array $batchHeaders): array
     {
         $headers = [];
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -88,7 +88,7 @@ class Client
      * @param null|HttpClient $httpClient
      * @param bool            $enableBeta
      */
-    public function __construct(HttpClient $httpClient = null, $enableBeta = false)
+    public function __construct(?HttpClient $httpClient = null, bool $enableBeta = false)
     {
         $this->httpClient = $httpClient ?: HttpClientDiscovery::find();
         $this->enableBetaMode = $enableBeta;
@@ -99,7 +99,7 @@ class Client
      *
      * @param HttpClient $httpClient
      */
-    public function setHttpClient(HttpClient $httpClient)
+    public function setHttpClient(HttpClient $httpClient): void
     {
         $this->httpClient = $httpClient;
     }
@@ -109,7 +109,7 @@ class Client
      *
      * @return HttpClient
      */
-    public function getHttpClient()
+    public function getHttpClient(): HttpClient
     {
         return $this->httpClient;
     }
@@ -119,7 +119,7 @@ class Client
      *
      * @param bool $betaMode
      */
-    public function enableBetaMode($betaMode = true)
+    public function enableBetaMode(bool $betaMode = true): void
     {
         $this->enableBetaMode = $betaMode;
     }
@@ -131,7 +131,7 @@ class Client
      *
      * @return string
      */
-    public function getBaseGraphUrl($postToVideoUrl = false)
+    public function getBaseGraphUrl(bool $postToVideoUrl = false): string
     {
         if ($postToVideoUrl) {
             return $this->enableBetaMode ? static::BASE_GRAPH_VIDEO_URL_BETA : static::BASE_GRAPH_VIDEO_URL;
@@ -147,7 +147,7 @@ class Client
      *
      * @return array
      */
-    public function prepareRequestMessage(Request $request)
+    public function prepareRequestMessage(Request $request): array
     {
         $postToVideoUrl = $request->containsVideoUploads();
         $url = $this->getBaseGraphUrl($postToVideoUrl) . $request->getUrl();
@@ -182,7 +182,7 @@ class Client
      *
      * @return Response
      */
-    public function sendRequest(Request $request)
+    public function sendRequest(Request $request): Response
     {
         if (get_class($request) === 'Facebook\Request') {
             $request->validateAccessToken();
@@ -225,7 +225,7 @@ class Client
      *
      * @return BatchResponse
      */
-    public function sendBatchRequest(BatchRequest $request)
+    public function sendBatchRequest(BatchRequest $request): BatchResponse
     {
         $request->prepareRequestsForBatch();
         $Response = $this->sendRequest($request);

--- a/src/Exception/ResponseException.php
+++ b/src/Exception/ResponseException.php
@@ -43,9 +43,9 @@ class ResponseException extends SDKException
      * Creates a ResponseException.
      *
      * @param Response     $response          the response that threw the exception
-     * @param SDKException $previousException the more detailed exception
+     * @param SDKException|null $previousException the more detailed exception
      */
-    public function __construct(Response $response, SDKException $previousException = null)
+    public function __construct(Response $response, ?SDKException $previousException = null)
     {
         $this->response = $response;
         $this->responseData = $response->getDecodedBody();
@@ -63,7 +63,7 @@ class ResponseException extends SDKException
      *
      * @return ResponseException
      */
-    public static function create(Response $response)
+    public static function create(Response $response): ResponseException
     {
         $data = $response->getDecodedBody();
 
@@ -142,7 +142,7 @@ class ResponseException extends SDKException
      *
      * @return mixed
      */
-    private function get($key, $default = null)
+    private function get(string $key, $default = null)
     {
         if (isset($this->responseData['error'][$key])) {
             return $this->responseData['error'][$key];
@@ -156,7 +156,7 @@ class ResponseException extends SDKException
      *
      * @return int
      */
-    public function getHttpStatusCode()
+    public function getHttpStatusCode(): int
     {
         return $this->response->getHttpStatusCode();
     }
@@ -166,7 +166,7 @@ class ResponseException extends SDKException
      *
      * @return int
      */
-    public function getSubErrorCode()
+    public function getSubErrorCode(): int
     {
         return $this->get('error_subcode', -1);
     }
@@ -176,7 +176,7 @@ class ResponseException extends SDKException
      *
      * @return string
      */
-    public function getErrorType()
+    public function getErrorType(): string
     {
         return $this->get('type', '');
     }
@@ -186,7 +186,7 @@ class ResponseException extends SDKException
      *
      * @return string
      */
-    public function getRawResponse()
+    public function getRawResponse(): string
     {
         return $this->response->getBody();
     }
@@ -196,7 +196,7 @@ class ResponseException extends SDKException
      *
      * @return array
      */
-    public function getResponseData()
+    public function getResponseData(): array
     {
         return $this->responseData;
     }
@@ -206,7 +206,7 @@ class ResponseException extends SDKException
      *
      * @return Response
      */
-    public function getResponse()
+    public function getResponse(): Response
     {
         return $this->response;
     }

--- a/src/Facebook.php
+++ b/src/Facebook.php
@@ -154,7 +154,7 @@ class Facebook
      *
      * @return Application
      */
-    public function getApplication()
+    public function getApplication(): Application
     {
         return $this->app;
     }
@@ -164,7 +164,7 @@ class Facebook
      *
      * @return Client
      */
-    public function getClient()
+    public function getClient(): Client
     {
         return $this->client;
     }
@@ -174,7 +174,7 @@ class Facebook
      *
      * @return OAuth2Client
      */
-    public function getOAuth2Client()
+    public function getOAuth2Client(): OAuth2Client
     {
         if (!$this->oAuth2Client instanceof OAuth2Client) {
             $app = $this->getApplication();
@@ -200,7 +200,7 @@ class Facebook
      *
      * @return UrlDetectionInterface
      */
-    public function getUrlDetectionHandler()
+    public function getUrlDetectionHandler(): UrlDetectionInterface
     {
         return $this->urlDetectionHandler;
     }
@@ -210,7 +210,7 @@ class Facebook
      *
      * @param UrlDetectionInterface $urlDetectionHandler
      */
-    private function setUrlDetectionHandler(UrlDetectionInterface $urlDetectionHandler)
+    private function setUrlDetectionHandler(UrlDetectionInterface $urlDetectionHandler): void
     {
         $this->urlDetectionHandler = $urlDetectionHandler;
     }
@@ -220,7 +220,7 @@ class Facebook
      *
      * @return null|AccessToken
      */
-    public function getDefaultAccessToken()
+    public function getDefaultAccessToken(): ?AccessToken
     {
         return $this->defaultAccessToken;
     }
@@ -232,7 +232,7 @@ class Facebook
      *
      * @throws \InvalidArgumentException
      */
-    public function setDefaultAccessToken($accessToken)
+    public function setDefaultAccessToken($accessToken): void
     {
         if (is_string($accessToken)) {
             $this->defaultAccessToken = new AccessToken($accessToken);
@@ -254,7 +254,7 @@ class Facebook
      *
      * @return string
      */
-    public function getDefaultGraphVersion()
+    public function getDefaultGraphVersion(): string
     {
         return $this->defaultGraphVersion;
     }
@@ -264,7 +264,7 @@ class Facebook
      *
      * @return RedirectLoginHelper
      */
-    public function getRedirectLoginHelper()
+    public function getRedirectLoginHelper(): RedirectLoginHelper
     {
         return new RedirectLoginHelper(
             $this->getOAuth2Client(),
@@ -278,7 +278,7 @@ class Facebook
      *
      * @return JavaScriptHelper
      */
-    public function getJavaScriptHelper()
+    public function getJavaScriptHelper(): JavaScriptHelper
     {
         return new JavaScriptHelper($this->app, $this->client, $this->defaultGraphVersion);
     }
@@ -288,7 +288,7 @@ class Facebook
      *
      * @return CanvasHelper
      */
-    public function getCanvasHelper()
+    public function getCanvasHelper(): CanvasHelper
     {
         return new CanvasHelper($this->app, $this->client, $this->defaultGraphVersion);
     }
@@ -298,7 +298,7 @@ class Facebook
      *
      * @return PageTabHelper
      */
-    public function getPageTabHelper()
+    public function getPageTabHelper(): PageTabHelper
     {
         return new PageTabHelper($this->app, $this->client, $this->defaultGraphVersion);
     }
@@ -315,8 +315,12 @@ class Facebook
      *
      * @return Response
      */
-    public function get($endpoint, $accessToken = null, $eTag = null, $graphVersion = null)
-    {
+    public function get(
+        string $endpoint,
+        $accessToken = null,
+        ?string $eTag = null,
+        ?string $graphVersion = null
+    ): Response {
         return $this->sendRequest(
             'GET',
             $endpoint,
@@ -340,8 +344,13 @@ class Facebook
      *
      * @return Response
      */
-    public function post($endpoint, array $params = [], $accessToken = null, $eTag = null, $graphVersion = null)
-    {
+    public function post(
+        string $endpoint,
+        array $params = [],
+        $accessToken = null,
+        ?string $eTag = null,
+        ?string $graphVersion = null
+    ): Response {
         return $this->sendRequest(
             'POST',
             $endpoint,
@@ -365,8 +374,13 @@ class Facebook
      *
      * @return Response
      */
-    public function delete($endpoint, array $params = [], $accessToken = null, $eTag = null, $graphVersion = null)
-    {
+    public function delete(
+        string $endpoint,
+        array $params = [],
+        $accessToken = null,
+        ?string $eTag = null,
+        ?string $graphVersion = null
+    ): Response {
         return $this->sendRequest(
             'DELETE',
             $endpoint,
@@ -386,7 +400,7 @@ class Facebook
      *
      * @return null|GraphEdge
      */
-    public function next(GraphEdge $graphEdge)
+    public function next(GraphEdge $graphEdge): ?GraphEdge
     {
         return $this->getPaginationResults($graphEdge, 'next');
     }
@@ -400,7 +414,7 @@ class Facebook
      *
      * @return null|GraphEdge
      */
-    public function previous(GraphEdge $graphEdge)
+    public function previous(GraphEdge $graphEdge): ?GraphEdge
     {
         return $this->getPaginationResults($graphEdge, 'previous');
     }
@@ -415,7 +429,7 @@ class Facebook
      *
      * @return null|GraphEdge
      */
-    public function getPaginationResults(GraphEdge $graphEdge, $direction)
+    public function getPaginationResults(GraphEdge $graphEdge, string $direction): ?GraphEdge
     {
         $paginationRequest = $graphEdge->getPaginationRequest($direction);
         if (!$paginationRequest) {
@@ -445,8 +459,14 @@ class Facebook
      *
      * @return Response
      */
-    public function sendRequest($method, $endpoint, array $params = [], $accessToken = null, $eTag = null, $graphVersion = null)
-    {
+    public function sendRequest(
+        string $method,
+        string $endpoint,
+        array $params = [],
+        $accessToken = null,
+        ?string $eTag = null,
+        ?string $graphVersion = null
+    ): Response {
         $accessToken = $accessToken ?: $this->defaultAccessToken;
         $graphVersion = $graphVersion ?: $this->defaultGraphVersion;
         $request = $this->request($method, $endpoint, $params, $accessToken, $eTag, $graphVersion);
@@ -465,7 +485,7 @@ class Facebook
      *
      * @return BatchResponse
      */
-    public function sendBatchRequest(array $requests, $accessToken = null, $graphVersion = null)
+    public function sendBatchRequest(array $requests, $accessToken = null, ?string $graphVersion = null): BatchResponse
     {
         $accessToken = $accessToken ?: $this->defaultAccessToken;
         $graphVersion = $graphVersion ?: $this->defaultGraphVersion;
@@ -488,7 +508,7 @@ class Facebook
      *
      * @return BatchRequest
      */
-    public function newBatchRequest($accessToken = null, $graphVersion = null)
+    public function newBatchRequest($accessToken = null, ?string $graphVersion = null): BatchRequest
     {
         $accessToken = $accessToken ?: $this->defaultAccessToken;
         $graphVersion = $graphVersion ?: $this->defaultGraphVersion;
@@ -515,8 +535,14 @@ class Facebook
      *
      * @return Request
      */
-    public function request($method, $endpoint, array $params = [], $accessToken = null, $eTag = null, $graphVersion = null)
-    {
+    public function request(
+        string $method,
+        string $endpoint,
+        array $params = [],
+        $accessToken = null,
+        string $eTag = '',
+        ?string $graphVersion = null
+    ): Request {
         $accessToken = $accessToken ?: $this->defaultAccessToken;
         $graphVersion = $graphVersion ?: $this->defaultGraphVersion;
 
@@ -540,7 +566,7 @@ class Facebook
      *
      * @return File
      */
-    public function fileToUpload($pathToFile)
+    public function fileToUpload(string $pathToFile): File
     {
         return new File($pathToFile);
     }
@@ -554,7 +580,7 @@ class Facebook
      *
      * @return Video
      */
-    public function videoToUpload($pathToFile)
+    public function videoToUpload(string $pathToFile): Video
     {
         return new Video($pathToFile);
     }
@@ -573,8 +599,14 @@ class Facebook
      *
      * @return array
      */
-    public function uploadVideo($target, $pathToFile, $metadata = [], $accessToken = null, $maxTransferTries = 5, $graphVersion = null)
-    {
+    public function uploadVideo(
+        int $target,
+        string $pathToFile,
+        array $metadata = [],
+        $accessToken = null,
+        int $maxTransferTries = 5,
+        ?string $graphVersion = null
+    ): array {
         $accessToken = $accessToken ?: $this->defaultAccessToken;
         $graphVersion = $graphVersion ?: $this->defaultGraphVersion;
 
@@ -605,8 +637,12 @@ class Facebook
      *
      * @return TransferChunk
      */
-    private function maxTriesTransfer(ResumableUploader $uploader, $endpoint, TransferChunk $chunk, $retryCountdown)
-    {
+    private function maxTriesTransfer(
+        ResumableUploader $uploader,
+        string $endpoint,
+        TransferChunk $chunk,
+        int $retryCountdown
+    ): TransferChunk {
         $newChunk = $uploader->transfer($endpoint, $chunk, $retryCountdown < 1);
 
         if ($newChunk !== $chunk) {

--- a/src/Facebook.php
+++ b/src/Facebook.php
@@ -308,7 +308,7 @@ class Facebook
      *
      * @param string                  $endpoint
      * @param null|AccessToken|string $accessToken
-     * @param null|string             $eTag
+     * @param string                  $eTag
      * @param null|string             $graphVersion
      *
      * @throws SDKException
@@ -318,7 +318,7 @@ class Facebook
     public function get(
         string $endpoint,
         $accessToken = null,
-        ?string $eTag = null,
+        string $eTag = '',
         ?string $graphVersion = null
     ): Response {
         return $this->sendRequest(
@@ -337,7 +337,7 @@ class Facebook
      * @param string                  $endpoint
      * @param array                   $params
      * @param null|AccessToken|string $accessToken
-     * @param null|string             $eTag
+     * @param string                  $eTag
      * @param null|string             $graphVersion
      *
      * @throws SDKException
@@ -348,7 +348,7 @@ class Facebook
         string $endpoint,
         array $params = [],
         $accessToken = null,
-        ?string $eTag = null,
+        string $eTag = '',
         ?string $graphVersion = null
     ): Response {
         return $this->sendRequest(
@@ -367,7 +367,7 @@ class Facebook
      * @param string                  $endpoint
      * @param array                   $params
      * @param null|AccessToken|string $accessToken
-     * @param null|string             $eTag
+     * @param string                  $eTag
      * @param null|string             $graphVersion
      *
      * @throws SDKException
@@ -378,7 +378,7 @@ class Facebook
         string $endpoint,
         array $params = [],
         $accessToken = null,
-        ?string $eTag = null,
+        string $eTag = '',
         ?string $graphVersion = null
     ): Response {
         return $this->sendRequest(
@@ -452,7 +452,7 @@ class Facebook
      * @param string                  $endpoint
      * @param array                   $params
      * @param null|AccessToken|string $accessToken
-     * @param null|string             $eTag
+     * @param string                  $eTag
      * @param null|string             $graphVersion
      *
      * @throws SDKException
@@ -464,7 +464,7 @@ class Facebook
         string $endpoint,
         array $params = [],
         $accessToken = null,
-        ?string $eTag = null,
+        string $eTag = '',
         ?string $graphVersion = null
     ): Response {
         $accessToken = $accessToken ?: $this->defaultAccessToken;
@@ -528,7 +528,7 @@ class Facebook
      * @param string                  $endpoint
      * @param array                   $params
      * @param null|AccessToken|string $accessToken
-     * @param null|string             $eTag
+     * @param string                  $eTag
      * @param null|string             $graphVersion
      *
      * @throws SDKException

--- a/src/FileUpload/File.php
+++ b/src/FileUpload/File.php
@@ -58,7 +58,7 @@ class File
      *
      * @throws SDKException
      */
-    public function __construct($filePath, $maxLength = -1, $offset = -1)
+    public function __construct(string $filePath, int $maxLength = -1, int $offset = -1)
     {
         $this->path = $filePath;
         $this->maxLength = $maxLength;
@@ -79,7 +79,7 @@ class File
      *
      * @throws SDKException
      */
-    public function open()
+    public function open(): void
     {
         if (!$this->isRemoteFile($this->path) && !is_readable($this->path)) {
             throw new SDKException('Failed to create File entity. Unable to read resource: ' . $this->path . '.');
@@ -95,7 +95,7 @@ class File
     /**
      * Stops the file stream.
      */
-    public function close()
+    public function close(): void
     {
         if (is_resource($this->stream)) {
             fclose($this->stream);
@@ -107,7 +107,7 @@ class File
      *
      * @return string
      */
-    public function getContents()
+    public function getContents(): string
     {
         return stream_get_contents($this->stream, $this->maxLength, $this->offset);
     }
@@ -117,7 +117,7 @@ class File
      *
      * @return string
      */
-    public function getFileName()
+    public function getFileName(): string
     {
         return basename($this->path);
     }
@@ -127,7 +127,7 @@ class File
      *
      * @return string
      */
-    public function getFilePath()
+    public function getFilePath(): string
     {
         return $this->path;
     }
@@ -137,7 +137,7 @@ class File
      *
      * @return int
      */
-    public function getSize()
+    public function getSize(): int
     {
         return filesize($this->path);
     }
@@ -147,7 +147,7 @@ class File
      *
      * @return string
      */
-    public function getMimetype()
+    public function getMimetype(): string
     {
         return Mimetypes::getInstance()->fromFilename($this->path) ?: 'text/plain';
     }
@@ -159,7 +159,7 @@ class File
      *
      * @return bool
      */
-    protected function isRemoteFile($pathToFile)
+    protected function isRemoteFile(string $pathToFile): bool
     {
         return preg_match('/^(https?|ftp):\/\/.*/', $pathToFile) === 1;
     }

--- a/src/FileUpload/Mimetypes.php
+++ b/src/FileUpload/Mimetypes.php
@@ -949,7 +949,7 @@ class Mimetypes
      * @return self
      * @codeCoverageIgnore
      */
-    public static function getInstance()
+    public static function getInstance(): self
     {
         if (!self::$instance) {
             self::$instance = new self();
@@ -965,7 +965,7 @@ class Mimetypes
      *
      * @return null|string
      */
-    public function fromExtension($extension)
+    public function fromExtension(string $extension): ?string
     {
         $extension = strtolower($extension);
 
@@ -979,7 +979,7 @@ class Mimetypes
      *
      * @return null|string
      */
-    public function fromFilename($filename)
+    public function fromFilename(string $filename): ?string
     {
         return $this->fromExtension(pathinfo($filename, PATHINFO_EXTENSION));
     }

--- a/src/FileUpload/ResumableUploader.php
+++ b/src/FileUpload/ResumableUploader.php
@@ -61,7 +61,7 @@ class ResumableUploader
      * @param null|AccessToken|string $accessToken
      * @param string                  $graphVersion
      */
-    public function __construct(Application $app, Client $client, $accessToken, $graphVersion)
+    public function __construct(Application $app, Client $client, $accessToken, string $graphVersion)
     {
         $this->app = $app;
         $this->client = $client;
@@ -79,7 +79,7 @@ class ResumableUploader
      *
      * @return TransferChunk
      */
-    public function start($endpoint, File $file)
+    public function start(string $endpoint, File $file): TransferChunk
     {
         $params = [
             'upload_phase' => 'start',
@@ -101,7 +101,7 @@ class ResumableUploader
      *
      * @return TransferChunk
      */
-    public function transfer($endpoint, TransferChunk $chunk, $allowToThrow = false)
+    public function transfer(string $endpoint, TransferChunk $chunk, bool $allowToThrow = false): TransferChunk
     {
         $params = [
             'upload_phase' => 'transfer',
@@ -136,7 +136,7 @@ class ResumableUploader
      *
      * @return bool
      */
-    public function finish($endpoint, $uploadSessionId, $metadata = [])
+    public function finish(string $endpoint, string $uploadSessionId, array $metadata = []): bool
     {
         $params = array_merge($metadata, [
             'upload_phase' => 'finish',
@@ -155,9 +155,9 @@ class ResumableUploader
      *
      * @return array
      */
-    private function sendUploadRequest($endpoint, $params = [])
+    private function sendUploadRequest(string $endpoint, array $params = []): array
     {
-        $request = new Request($this->app, $this->accessToken, 'POST', $endpoint, $params, null, $this->graphVersion);
+        $request = new Request($this->app, $this->accessToken, 'POST', $endpoint, $params, '', $this->graphVersion);
 
         return $this->client->sendRequest($request)->getDecodedBody();
     }

--- a/src/FileUpload/TransferChunk.php
+++ b/src/FileUpload/TransferChunk.php
@@ -59,7 +59,7 @@ class TransferChunk
      * @param int  $startOffset
      * @param int  $endOffset
      */
-    public function __construct(File $file, $uploadSessionId, $videoId, $startOffset, $endOffset)
+    public function __construct(File $file, int $uploadSessionId, int $videoId, int $startOffset, int $endOffset)
     {
         $this->file = $file;
         $this->uploadSessionId = $uploadSessionId;
@@ -73,7 +73,7 @@ class TransferChunk
      *
      * @return File
      */
-    public function getFile()
+    public function getFile(): File
     {
         return $this->file;
     }
@@ -83,7 +83,7 @@ class TransferChunk
      *
      * @return File
      */
-    public function getPartialFile()
+    public function getPartialFile(): File
     {
         $maxLength = $this->endOffset - $this->startOffset;
 
@@ -95,7 +95,7 @@ class TransferChunk
      *
      * @return int
      */
-    public function getUploadSessionId()
+    public function getUploadSessionId(): int
     {
         return $this->uploadSessionId;
     }
@@ -105,7 +105,7 @@ class TransferChunk
      *
      * @return bool
      */
-    public function isLastChunk()
+    public function isLastChunk(): bool
     {
         return $this->startOffset === $this->endOffset;
     }
@@ -113,7 +113,7 @@ class TransferChunk
     /**
      * @return int
      */
-    public function getStartOffset()
+    public function getStartOffset(): int
     {
         return $this->startOffset;
     }
@@ -123,7 +123,7 @@ class TransferChunk
      *
      * @return int
      */
-    public function getVideoId()
+    public function getVideoId(): int
     {
         return $this->videoId;
     }

--- a/src/GraphNode/Birthday.php
+++ b/src/GraphNode/Birthday.php
@@ -52,7 +52,7 @@ class Birthday extends DateTime
      *
      * @param string $date
      */
-    public function __construct($date)
+    public function __construct(string $date)
     {
         $parts = explode('/', $date);
 
@@ -67,7 +67,7 @@ class Birthday extends DateTime
      *
      * @return bool
      */
-    public function hasDate()
+    public function hasDate(): bool
     {
         return $this->hasDate;
     }
@@ -77,7 +77,7 @@ class Birthday extends DateTime
      *
      * @return bool
      */
-    public function hasYear()
+    public function hasYear(): bool
     {
         return $this->hasYear;
     }

--- a/src/GraphNode/GraphAchievement.php
+++ b/src/GraphNode/GraphAchievement.php
@@ -40,7 +40,7 @@ class GraphAchievement extends GraphNode
      *
      * @return null|string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->getField('id');
     }
@@ -50,7 +50,7 @@ class GraphAchievement extends GraphNode
      *
      * @return null|GraphUser
      */
-    public function getFrom()
+    public function getFrom(): ?GraphUser
     {
         return $this->getField('from');
     }
@@ -60,7 +60,7 @@ class GraphAchievement extends GraphNode
      *
      * @return null|\DateTime
      */
-    public function getPublishTime()
+    public function getPublishTime(): ?\DateTime
     {
         return $this->getField('publish_time');
     }
@@ -70,7 +70,7 @@ class GraphAchievement extends GraphNode
      *
      * @return null|GraphApplication
      */
-    public function getApplication()
+    public function getApplication(): ?GraphApplication
     {
         return $this->getField('application');
     }
@@ -80,7 +80,7 @@ class GraphAchievement extends GraphNode
      *
      * @return null|array
      */
-    public function getData()
+    public function getData(): ?array
     {
         return $this->getField('data');
     }
@@ -92,7 +92,7 @@ class GraphAchievement extends GraphNode
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return 'game.achievement';
     }
@@ -102,7 +102,7 @@ class GraphAchievement extends GraphNode
      *
      * @return null|bool
      */
-    public function isNoFeedStory()
+    public function isNoFeedStory(): ?bool
     {
         return $this->getField('no_feed_story');
     }

--- a/src/GraphNode/GraphAlbum.php
+++ b/src/GraphNode/GraphAlbum.php
@@ -22,6 +22,8 @@
  */
 namespace Facebook\GraphNode;
 
+use Prophecy\PhpDocumentor\ClassTagRetriever;
+
 /**
  * @package Facebook
  */
@@ -41,7 +43,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->getField('id');
     }
@@ -51,7 +53,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|bool
      */
-    public function getCanUpload()
+    public function getCanUpload(): ?bool
     {
         return $this->getField('can_upload');
     }
@@ -61,7 +63,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|int
      */
-    public function getCount()
+    public function getCount(): ?int
     {
         return $this->getField('count');
     }
@@ -71,7 +73,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|string
      */
-    public function getCoverPhoto()
+    public function getCoverPhoto(): ?string
     {
         return $this->getField('cover_photo');
     }
@@ -81,7 +83,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|\DateTime
      */
-    public function getCreatedTime()
+    public function getCreatedTime(): ?\DateTime
     {
         return $this->getField('created_time');
     }
@@ -91,7 +93,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|\DateTime
      */
-    public function getUpdatedTime()
+    public function getUpdatedTime(): ?\DateTime
     {
         return $this->getField('updated_time');
     }
@@ -101,7 +103,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|string
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->getField('description');
     }
@@ -111,7 +113,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|GraphUser
      */
-    public function getFrom()
+    public function getFrom(): ?GraphUser
     {
         return $this->getField('from');
     }
@@ -121,7 +123,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|GraphPage
      */
-    public function getPlace()
+    public function getPlace(): ?GraphPage
     {
         return $this->getField('place');
     }
@@ -131,7 +133,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|string
      */
-    public function getLink()
+    public function getLink(): ?string
     {
         return $this->getField('link');
     }
@@ -141,7 +143,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|string
      */
-    public function getLocation()
+    public function getLocation(): ?string
     {
         return $this->getField('location');
     }
@@ -151,7 +153,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->getField('name');
     }
@@ -161,7 +163,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|string
      */
-    public function getPrivacy()
+    public function getPrivacy(): ?string
     {
         return $this->getField('privacy');
     }
@@ -173,7 +175,7 @@ class GraphAlbum extends GraphNode
      *
      * @return null|string
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->getField('type');
     }

--- a/src/GraphNode/GraphApplication.php
+++ b/src/GraphNode/GraphApplication.php
@@ -33,7 +33,7 @@ class GraphApplication extends GraphNode
      *
      * @return null|string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->getField('id');
     }

--- a/src/GraphNode/GraphCoverPhoto.php
+++ b/src/GraphNode/GraphCoverPhoto.php
@@ -32,7 +32,7 @@ class GraphCoverPhoto extends GraphNode
      *
      * @return null|int
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->getField('id');
     }
@@ -42,7 +42,7 @@ class GraphCoverPhoto extends GraphNode
      *
      * @return null|string
      */
-    public function getSource()
+    public function getSource(): ?string
     {
         return $this->getField('source');
     }
@@ -52,7 +52,7 @@ class GraphCoverPhoto extends GraphNode
      *
      * @return null|int
      */
-    public function getOffsetX()
+    public function getOffsetX(): ?int
     {
         return $this->getField('offset_x');
     }
@@ -62,7 +62,7 @@ class GraphCoverPhoto extends GraphNode
      *
      * @return null|int
      */
-    public function getOffsetY()
+    public function getOffsetY(): ?int
     {
         return $this->getField('offset_y');
     }

--- a/src/GraphNode/GraphEdge.php
+++ b/src/GraphNode/GraphEdge.php
@@ -67,8 +67,13 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      * @param null|string $parentEdgeEndpoint the parent Graph edge endpoint that generated the list
      * @param null|string $subclassName       the subclass of the child GraphNode's
      */
-    public function __construct(Request $request, array $data = [], array $metaData = [], $parentEdgeEndpoint = null, $subclassName = null)
-    {
+    public function __construct(
+        Request $request,
+        array $data = [],
+        array $metaData = [],
+        ?string $parentEdgeEndpoint = null,
+        ?string $subclassName = null
+    ) {
         $this->request = $request;
         $this->metaData = $metaData;
         $this->parentEdgeEndpoint = $parentEdgeEndpoint;
@@ -84,7 +89,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return mixed
      */
-    public function getField($name, $default = null)
+    public function getField(string $name, $default = null)
     {
         if (isset($this->items[$name])) {
             return $this->items[$name];
@@ -98,7 +103,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return array
      */
-    public function getFieldNames()
+    public function getFieldNames(): array
     {
         return array_keys($this->items);
     }
@@ -108,7 +113,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return array
      */
-    public function all()
+    public function all(): array
     {
         return $this->items;
     }
@@ -118,7 +123,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return array
      */
-    public function asArray()
+    public function asArray(): array
     {
         return array_map(function ($value) {
             if ($value instanceof GraphNode || $value instanceof GraphEdge) {
@@ -150,7 +155,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return string
      */
-    public function asJson($options = 0)
+    public function asJson(int $options = 0): string
     {
         return json_encode($this->asArray(), $options);
     }
@@ -160,7 +165,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->items);
     }
@@ -170,7 +175,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->items);
     }
@@ -178,11 +183,11 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Determine if an item exists at an offset.
      *
-     * @param mixed $key
+     * @param array-key $key
      *
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return array_key_exists($key, $this->items);
     }
@@ -190,7 +195,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Get an item at a given offset.
      *
-     * @param mixed $key
+     * @param array-key $key
      *
      * @return mixed
      */
@@ -202,12 +207,12 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Set the item at a given offset.
      *
-     * @param mixed $key
+     * @param array-key $key
      * @param mixed $value
      *
      * @return void
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         if (is_null($key)) {
             $this->items[] = $value;
@@ -219,11 +224,11 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Unset the item at a given offset.
      *
-     * @param string $key
+     * @param array-key $key
      *
      * @return void
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         unset($this->items[$key]);
     }
@@ -233,7 +238,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->asJson();
     }
@@ -243,7 +248,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return null|string
      */
-    public function getParentGraphEdge()
+    public function getParentGraphEdge(): ?string
     {
         return $this->parentEdgeEndpoint;
     }
@@ -253,7 +258,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return null|string
      */
-    public function getSubClassName()
+    public function getSubClassName(): ?string
     {
         return $this->subclassName;
     }
@@ -263,7 +268,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return array
      */
-    public function getMetaData()
+    public function getMetaData(): array
     {
         return $this->metaData;
     }
@@ -273,7 +278,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return null|string
      */
-    public function getNextCursor()
+    public function getNextCursor(): ?string
     {
         return $this->getCursor('after');
     }
@@ -283,7 +288,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return null|string
      */
-    public function getPreviousCursor()
+    public function getPreviousCursor(): ?string
     {
         return $this->getCursor('before');
     }
@@ -295,7 +300,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return null|string
      */
-    public function getCursor($direction)
+    public function getCursor(string $direction): ?string
     {
         if (isset($this->metaData['paging']['cursors'][$direction])) {
             return $this->metaData['paging']['cursors'][$direction];
@@ -313,7 +318,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return null|string
      */
-    public function getPaginationUrl($direction)
+    public function getPaginationUrl(string $direction): ?string
     {
         $this->validateForPagination();
 
@@ -332,7 +337,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @throws SDKException
      */
-    public function validateForPagination()
+    public function validateForPagination(): void
     {
         if ($this->request->getMethod() !== 'GET') {
             throw new SDKException('You can only paginate on a GET request.', 720);
@@ -348,7 +353,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return null|Request
      */
-    public function getPaginationRequest($direction)
+    public function getPaginationRequest(string $direction): ?Request
     {
         $pageUrl = $this->getPaginationUrl($direction);
         if (!$pageUrl) {
@@ -368,7 +373,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return null|Request
      */
-    public function getNextPageRequest()
+    public function getNextPageRequest(): ?Request
     {
         return $this->getPaginationRequest('next');
     }
@@ -380,7 +385,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return null|Request
      */
-    public function getPreviousPageRequest()
+    public function getPreviousPageRequest(): ?Request
     {
         return $this->getPaginationRequest('previous');
     }
@@ -392,7 +397,7 @@ class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return null|int
      */
-    public function getTotalCount()
+    public function getTotalCount(): ?int
     {
         if (isset($this->metaData['summary']['total_count'])) {
             return $this->metaData['summary']['total_count'];

--- a/src/GraphNode/GraphEvent.php
+++ b/src/GraphNode/GraphEvent.php
@@ -42,7 +42,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->getField('id');
     }
@@ -52,7 +52,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|GraphCoverPhoto
      */
-    public function getCover()
+    public function getCover(): ?GraphCoverPhoto
     {
         return $this->getField('cover');
     }
@@ -62,7 +62,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|string
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->getField('description');
     }
@@ -72,7 +72,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|\DateTime
      */
-    public function getEndTime()
+    public function getEndTime(): ?\DateTime
     {
         return $this->getField('end_time');
     }
@@ -82,7 +82,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|bool
      */
-    public function getIsDateOnly()
+    public function getIsDateOnly(): ?bool
     {
         return $this->getField('is_date_only');
     }
@@ -92,7 +92,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->getField('name');
     }
@@ -102,7 +102,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|GraphNode
      */
-    public function getOwner()
+    public function getOwner(): ?GraphNode
     {
         return $this->getField('owner');
     }
@@ -112,7 +112,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|GraphGroup
      */
-    public function getParentGroup()
+    public function getParentGroup(): ?GraphGroup
     {
         return $this->getField('parent_group');
     }
@@ -122,7 +122,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|GraphPage
      */
-    public function getPlace()
+    public function getPlace(): ?GraphPage
     {
         return $this->getField('place');
     }
@@ -132,7 +132,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|string
      */
-    public function getPrivacy()
+    public function getPrivacy(): ?string
     {
         return $this->getField('privacy');
     }
@@ -142,7 +142,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|\DateTime
      */
-    public function getStartTime()
+    public function getStartTime(): ?\DateTime
     {
         return $this->getField('start_time');
     }
@@ -152,7 +152,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|string
      */
-    public function getTicketUri()
+    public function getTicketUri(): ?string
     {
         return $this->getField('ticket_uri');
     }
@@ -162,7 +162,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|string
      */
-    public function getTimezone()
+    public function getTimezone(): ?string
     {
         return $this->getField('timezone');
     }
@@ -172,7 +172,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|\DateTime
      */
-    public function getUpdatedTime()
+    public function getUpdatedTime(): ?\DateTime
     {
         return $this->getField('updated_time');
     }
@@ -182,7 +182,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|GraphPicture
      */
-    public function getPicture()
+    public function getPicture(): ?GraphPicture
     {
         return $this->getField('picture');
     }
@@ -192,7 +192,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|int
      */
-    public function getAttendingCount()
+    public function getAttendingCount(): ?int
     {
         return $this->getField('attending_count');
     }
@@ -202,7 +202,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|int
      */
-    public function getDeclinedCount()
+    public function getDeclinedCount(): ?int
     {
         return $this->getField('declined_count');
     }
@@ -212,7 +212,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|int
      */
-    public function getMaybeCount()
+    public function getMaybeCount(): ?int
     {
         return $this->getField('maybe_count');
     }
@@ -222,7 +222,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|int
      */
-    public function getNoreplyCount()
+    public function getNoreplyCount(): ?int
     {
         return $this->getField('noreply_count');
     }
@@ -232,7 +232,7 @@ class GraphEvent extends GraphNode
      *
      * @return null|int
      */
-    public function getInvitedCount()
+    public function getInvitedCount(): ?int
     {
         return $this->getField('invited_count');
     }

--- a/src/GraphNode/GraphGroup.php
+++ b/src/GraphNode/GraphGroup.php
@@ -40,7 +40,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->getField('id');
     }
@@ -50,7 +50,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|GraphCoverPhoto
      */
-    public function getCover()
+    public function getCover(): ?GraphCoverPhoto
     {
         return $this->getField('cover');
     }
@@ -60,7 +60,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|string
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->getField('description');
     }
@@ -70,7 +70,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|string
      */
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->getField('email');
     }
@@ -80,7 +80,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|string
      */
-    public function getIcon()
+    public function getIcon(): ?string
     {
         return $this->getField('icon');
     }
@@ -90,7 +90,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|string
      */
-    public function getLink()
+    public function getLink(): ?string
     {
         return $this->getField('link');
     }
@@ -100,7 +100,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->getField('name');
     }
@@ -110,7 +110,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|int
      */
-    public function getMemberRequestCount()
+    public function getMemberRequestCount(): ?int
     {
         return $this->getField('member_request_count');
     }
@@ -120,7 +120,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|GraphNode
      */
-    public function getOwner()
+    public function getOwner(): ?GraphNode
     {
         return $this->getField('owner');
     }
@@ -130,7 +130,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|GraphNode
      */
-    public function getParent()
+    public function getParent(): ?GraphNode
     {
         return $this->getField('parent');
     }
@@ -140,7 +140,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|string
      */
-    public function getPrivacy()
+    public function getPrivacy(): ?string
     {
         return $this->getField('privacy');
     }
@@ -150,7 +150,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|\DateTime
      */
-    public function getUpdatedTime()
+    public function getUpdatedTime(): ?\DateTime
     {
         return $this->getField('updated_time');
     }
@@ -160,7 +160,7 @@ class GraphGroup extends GraphNode
      *
      * @return null|GraphLocation
      */
-    public function getVenue()
+    public function getVenue(): ?GraphLocation
     {
         return $this->getField('venue');
     }

--- a/src/GraphNode/GraphLocation.php
+++ b/src/GraphNode/GraphLocation.php
@@ -32,7 +32,7 @@ class GraphLocation extends GraphNode
      *
      * @return null|string
      */
-    public function getStreet()
+    public function getStreet(): ?string
     {
         return $this->getField('street');
     }
@@ -42,7 +42,7 @@ class GraphLocation extends GraphNode
      *
      * @return null|string
      */
-    public function getCity()
+    public function getCity(): ?string
     {
         return $this->getField('city');
     }
@@ -52,7 +52,7 @@ class GraphLocation extends GraphNode
      *
      * @return null|string
      */
-    public function getState()
+    public function getState(): ?string
     {
         return $this->getField('state');
     }
@@ -62,7 +62,7 @@ class GraphLocation extends GraphNode
      *
      * @return null|string
      */
-    public function getCountry()
+    public function getCountry(): ?string
     {
         return $this->getField('country');
     }
@@ -72,7 +72,7 @@ class GraphLocation extends GraphNode
      *
      * @return null|string
      */
-    public function getZip()
+    public function getZip(): ?string
     {
         return $this->getField('zip');
     }
@@ -82,7 +82,7 @@ class GraphLocation extends GraphNode
      *
      * @return null|float
      */
-    public function getLatitude()
+    public function getLatitude(): ?float
     {
         return $this->getField('latitude');
     }
@@ -92,7 +92,7 @@ class GraphLocation extends GraphNode
      *
      * @return null|float
      */
-    public function getLongitude()
+    public function getLongitude(): ?float
     {
         return $this->getField('longitude');
     }

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -57,7 +57,7 @@ class GraphNode
      *
      * @return mixed
      */
-    public function getField($name, $default = null)
+    public function getField(string $name, $default = null)
     {
         if (isset($this->fields[$name])) {
             return $this->fields[$name];
@@ -71,7 +71,7 @@ class GraphNode
      *
      * @return array
      */
-    public function getFieldNames()
+    public function getFieldNames(): array
     {
         return array_keys($this->fields);
     }
@@ -81,7 +81,7 @@ class GraphNode
      *
      * @return array
      */
-    public function getFields()
+    public function getFields(): array
     {
         return $this->fields;
     }
@@ -91,7 +91,7 @@ class GraphNode
      *
      * @return array
      */
-    public function asArray()
+    public function asArray(): array
     {
         return array_map(function ($value) {
             if ($value instanceof GraphNode || $value instanceof GraphEdge) {
@@ -107,7 +107,7 @@ class GraphNode
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode($this->uncastFields());
     }
@@ -117,7 +117,7 @@ class GraphNode
      *
      * @return array
      */
-    public static function getNodeMap()
+    public static function getNodeMap(): array
     {
         return static::$graphNodeMap;
     }
@@ -132,7 +132,7 @@ class GraphNode
      *
      * @return array
      */
-    private function castFields(array $data)
+    private function castFields(array $data): array
     {
         $fields = [];
 
@@ -158,7 +158,7 @@ class GraphNode
      *
      * @return array
      */
-    private function uncastFields()
+    private function uncastFields(): array
     {
         $fields = $this->asArray();
 
@@ -178,7 +178,7 @@ class GraphNode
      *
      * @return bool
      */
-    private function shouldCastAsDateTime($key)
+    private function shouldCastAsDateTime(string $key): bool
     {
         return in_array($key, [
             'created_time',
@@ -204,7 +204,7 @@ class GraphNode
      * @see http://www.cl.cam.ac.uk/~mgk25/iso-time.html
      * @see http://en.wikipedia.org/wiki/ISO_8601
      */
-    private function isIso8601DateString($string)
+    private function isIso8601DateString(string $string): bool
     {
         // This insane regex was yoinked from here:
         // http://www.pelagodesign.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/
@@ -227,7 +227,7 @@ class GraphNode
      *
      * @return \DateTime
      */
-    private function castToDateTime($value)
+    private function castToDateTime($value): \DateTime
     {
         if (is_int($value)) {
             $dt = new \DateTime();
@@ -246,7 +246,7 @@ class GraphNode
      *
      * @return Birthday
      */
-    private function castToBirthday($value)
+    private function castToBirthday(string $value): Birthday
     {
         return new Birthday($value);
     }

--- a/src/GraphNode/GraphNodeFactory.php
+++ b/src/GraphNode/GraphNodeFactory.php
@@ -86,7 +86,7 @@ class GraphNodeFactory
      *
      * @return GraphNode
      */
-    public function makeGraphNode($subclassName = null)
+    public function makeGraphNode(?string $subclassName = null): GraphNode
     {
         $this->validateResponseAsArray();
         $this->validateResponseCastableAsGraphNode();
@@ -101,7 +101,7 @@ class GraphNodeFactory
      *
      * @return GraphAchievement
      */
-    public function makeGraphAchievement()
+    public function makeGraphAchievement(): GraphAchievement
     {
         return $this->makeGraphNode(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphAchievement');
     }
@@ -113,7 +113,7 @@ class GraphNodeFactory
      *
      * @return GraphAlbum
      */
-    public function makeGraphAlbum()
+    public function makeGraphAlbum(): GraphAlbum
     {
         return $this->makeGraphNode(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphAlbum');
     }
@@ -125,7 +125,7 @@ class GraphNodeFactory
      *
      * @return GraphPage
      */
-    public function makeGraphPage()
+    public function makeGraphPage(): GraphPage
     {
         return $this->makeGraphNode(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphPage');
     }
@@ -137,7 +137,7 @@ class GraphNodeFactory
      *
      * @return GraphSessionInfo
      */
-    public function makeGraphSessionInfo()
+    public function makeGraphSessionInfo(): GraphSessionInfo
     {
         return $this->makeGraphNode(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphSessionInfo');
     }
@@ -149,7 +149,7 @@ class GraphNodeFactory
      *
      * @return GraphUser
      */
-    public function makeGraphUser()
+    public function makeGraphUser(): GraphUser
     {
         return $this->makeGraphNode(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphUser');
     }
@@ -161,7 +161,7 @@ class GraphNodeFactory
      *
      * @return GraphEvent
      */
-    public function makeGraphEvent()
+    public function makeGraphEvent(): GraphEvent
     {
         return $this->makeGraphNode(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphEvent');
     }
@@ -173,7 +173,7 @@ class GraphNodeFactory
      *
      * @return GraphGroup
      */
-    public function makeGraphGroup()
+    public function makeGraphGroup(): GraphGroup
     {
         return $this->makeGraphNode(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphGroup');
     }
@@ -188,7 +188,7 @@ class GraphNodeFactory
      *
      * @return GraphEdge
      */
-    public function makeGraphEdge($subclassName = null, $auto_prefix = true)
+    public function makeGraphEdge(?string $subclassName = null, bool $auto_prefix = true): GraphEdge
     {
         $this->validateResponseAsArray();
         $this->validateResponseCastableAsGraphEdge();
@@ -205,7 +205,7 @@ class GraphNodeFactory
      *
      * @throws SDKException
      */
-    public function validateResponseAsArray()
+    public function validateResponseAsArray(): void
     {
         if (!is_array($this->decodedBody)) {
             throw new SDKException('Unable to get response from Graph as array.', 620);
@@ -217,7 +217,7 @@ class GraphNodeFactory
      *
      * @throws SDKException
      */
-    public function validateResponseCastableAsGraphNode()
+    public function validateResponseCastableAsGraphNode(): void
     {
         if (isset($this->decodedBody['data']) && static::isCastableAsGraphEdge($this->decodedBody['data'])) {
             throw new SDKException(
@@ -232,7 +232,7 @@ class GraphNodeFactory
      *
      * @throws SDKException
      */
-    public function validateResponseCastableAsGraphEdge()
+    public function validateResponseCastableAsGraphEdge(): void
     {
         if (!(isset($this->decodedBody['data']) && static::isCastableAsGraphEdge($this->decodedBody['data']))) {
             throw new SDKException(
@@ -252,7 +252,7 @@ class GraphNodeFactory
      *
      * @return GraphNode
      */
-    public function safelyMakeGraphNode(array $data, $subclassName = null)
+    public function safelyMakeGraphNode(array $data, ?string $subclassName = null): GraphNode
     {
         $subclassName = $subclassName ?: static::BASE_GRAPH_NODE_CLASS;
         static::validateSubclass($subclassName);
@@ -293,8 +293,12 @@ class GraphNodeFactory
      *
      * @return GraphEdge|GraphNode
      */
-    public function castAsGraphNodeOrGraphEdge(array $data, $subclassName = null, $parentKey = null, $parentNodeId = null)
-    {
+    public function castAsGraphNodeOrGraphEdge(
+        array $data,
+        ?string $subclassName = null,
+        ?string $parentKey = null,
+        ?string $parentNodeId = null
+    ) {
         if (isset($data['data'])) {
             // Create GraphEdge
             if (static::isCastableAsGraphEdge($data['data'])) {
@@ -320,8 +324,12 @@ class GraphNodeFactory
      *
      * @return GraphEdge
      */
-    public function safelyMakeGraphEdge(array $data, $subclassName = null, $parentKey = null, $parentNodeId = null)
-    {
+    public function safelyMakeGraphEdge(
+        array $data,
+        ?string $subclassName = null,
+        ?string $parentKey = null,
+        ?string $parentNodeId = null
+    ): GraphEdge {
         if (!isset($data['data'])) {
             throw new SDKException('Cannot cast data to GraphEdge. Expected a "data" key.', 620);
         }
@@ -347,7 +355,7 @@ class GraphNodeFactory
      *
      * @return array
      */
-    public function getMetaData(array $data)
+    public function getMetaData(array $data): array
     {
         unset($data['data']);
 
@@ -361,7 +369,7 @@ class GraphNodeFactory
      *
      * @return bool
      */
-    public static function isCastableAsGraphEdge(array $data)
+    public static function isCastableAsGraphEdge(array $data): bool
     {
         if ($data === []) {
             return true;
@@ -378,7 +386,7 @@ class GraphNodeFactory
      *
      * @throws SDKException
      */
-    public static function validateSubclass($subclassName)
+    public static function validateSubclass(string $subclassName): void
     {
         if ($subclassName == static::BASE_GRAPH_NODE_CLASS || is_subclass_of($subclassName, static::BASE_GRAPH_NODE_CLASS)) {
             return;

--- a/src/GraphNode/GraphPage.php
+++ b/src/GraphNode/GraphPage.php
@@ -43,7 +43,7 @@ class GraphPage extends GraphNode
      *
      * @return null|string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->getField('id');
     }
@@ -53,7 +53,7 @@ class GraphPage extends GraphNode
      *
      * @return null|string
      */
-    public function getCategory()
+    public function getCategory(): ?string
     {
         return $this->getField('category');
     }
@@ -63,7 +63,7 @@ class GraphPage extends GraphNode
      *
      * @return null|string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->getField('name');
     }
@@ -73,7 +73,7 @@ class GraphPage extends GraphNode
      *
      * @return null|GraphPage
      */
-    public function getBestPage()
+    public function getBestPage(): ?GraphPage
     {
         return $this->getField('best_page');
     }
@@ -83,7 +83,7 @@ class GraphPage extends GraphNode
      *
      * @return null|GraphPage
      */
-    public function getGlobalBrandParentPage()
+    public function getGlobalBrandParentPage(): ?GraphPage
     {
         return $this->getField('global_brand_parent_page');
     }
@@ -93,7 +93,7 @@ class GraphPage extends GraphNode
      *
      * @return null|GraphLocation
      */
-    public function getLocation()
+    public function getLocation(): ?GraphLocation
     {
         return $this->getField('location');
     }
@@ -103,7 +103,7 @@ class GraphPage extends GraphNode
      *
      * @return null|GraphCoverPhoto
      */
-    public function getCover()
+    public function getCover(): ?GraphCoverPhoto
     {
         return $this->getField('cover');
     }
@@ -113,7 +113,7 @@ class GraphPage extends GraphNode
      *
      * @return null|GraphPicture
      */
-    public function getPicture()
+    public function getPicture(): ?GraphPicture
     {
         return $this->getField('picture');
     }
@@ -125,7 +125,7 @@ class GraphPage extends GraphNode
      *
      * @return null|string
      */
-    public function getAccessToken()
+    public function getAccessToken(): ?string
     {
         return $this->getField('access_token');
     }
@@ -137,7 +137,7 @@ class GraphPage extends GraphNode
      *
      * @return null|array
      */
-    public function getPerms()
+    public function getPerms(): ?array
     {
         return $this->getField('perms');
     }

--- a/src/GraphNode/GraphPicture.php
+++ b/src/GraphNode/GraphPicture.php
@@ -32,7 +32,7 @@ class GraphPicture extends GraphNode
      *
      * @return null|bool
      */
-    public function isSilhouette()
+    public function isSilhouette(): ?bool
     {
         return $this->getField('is_silhouette');
     }
@@ -42,7 +42,7 @@ class GraphPicture extends GraphNode
      *
      * @return null|string
      */
-    public function getUrl()
+    public function getUrl(): ?string
     {
         return $this->getField('url');
     }
@@ -52,7 +52,7 @@ class GraphPicture extends GraphNode
      *
      * @return null|int
      */
-    public function getWidth()
+    public function getWidth(): ?int
     {
         return $this->getField('width');
     }
@@ -62,7 +62,7 @@ class GraphPicture extends GraphNode
      *
      * @return null|int
      */
-    public function getHeight()
+    public function getHeight(): ?int
     {
         return $this->getField('height');
     }

--- a/src/GraphNode/GraphSessionInfo.php
+++ b/src/GraphNode/GraphSessionInfo.php
@@ -32,7 +32,7 @@ class GraphSessionInfo extends GraphNode
      *
      * @return null|string
      */
-    public function getAppId()
+    public function getAppId(): ?string
     {
         return $this->getField('app_id');
     }
@@ -42,7 +42,7 @@ class GraphSessionInfo extends GraphNode
      *
      * @return null|string
      */
-    public function getApplication()
+    public function getApplication(): ?string
     {
         return $this->getField('application');
     }
@@ -52,7 +52,7 @@ class GraphSessionInfo extends GraphNode
      *
      * @return null|\DateTime
      */
-    public function getExpiresAt()
+    public function getExpiresAt(): ?\DateTime
     {
         return $this->getField('expires_at');
     }
@@ -62,7 +62,7 @@ class GraphSessionInfo extends GraphNode
      *
      * @return bool
      */
-    public function getIsValid()
+    public function getIsValid(): bool
     {
         return $this->getField('is_valid');
     }
@@ -72,7 +72,7 @@ class GraphSessionInfo extends GraphNode
      *
      * @return null|\DateTime
      */
-    public function getIssuedAt()
+    public function getIssuedAt(): ?\DateTime
     {
         return $this->getField('issued_at');
     }
@@ -82,7 +82,7 @@ class GraphSessionInfo extends GraphNode
      *
      * @return array
      */
-    public function getScopes()
+    public function getScopes(): array
     {
         return $this->getField('scopes');
     }
@@ -92,7 +92,7 @@ class GraphSessionInfo extends GraphNode
      *
      * @return null|string
      */
-    public function getUserId()
+    public function getUserId(): ?string
     {
         return $this->getField('user_id');
     }

--- a/src/GraphNode/GraphUser.php
+++ b/src/GraphNode/GraphUser.php
@@ -42,7 +42,7 @@ class GraphUser extends GraphNode
      *
      * @return null|string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->getField('id');
     }
@@ -52,7 +52,7 @@ class GraphUser extends GraphNode
      *
      * @return null|string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->getField('name');
     }
@@ -62,7 +62,7 @@ class GraphUser extends GraphNode
      *
      * @return null|string
      */
-    public function getFirstName()
+    public function getFirstName(): ?string
     {
         return $this->getField('first_name');
     }
@@ -72,7 +72,7 @@ class GraphUser extends GraphNode
      *
      * @return null|string
      */
-    public function getMiddleName()
+    public function getMiddleName(): ?string
     {
         return $this->getField('middle_name');
     }
@@ -82,7 +82,7 @@ class GraphUser extends GraphNode
      *
      * @return null|string
      */
-    public function getLastName()
+    public function getLastName(): ?string
     {
         return $this->getField('last_name');
     }
@@ -92,7 +92,7 @@ class GraphUser extends GraphNode
      *
      * @return null|string
      */
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->getField('email');
     }
@@ -102,7 +102,7 @@ class GraphUser extends GraphNode
      *
      * @return null|string
      */
-    public function getGender()
+    public function getGender(): ?string
     {
         return $this->getField('gender');
     }
@@ -112,7 +112,7 @@ class GraphUser extends GraphNode
      *
      * @return null|string
      */
-    public function getLink()
+    public function getLink(): ?string
     {
         return $this->getField('link');
     }
@@ -122,7 +122,7 @@ class GraphUser extends GraphNode
      *
      * @return null|Birthday
      */
-    public function getBirthday()
+    public function getBirthday(): ?Birthday
     {
         return $this->getField('birthday');
     }
@@ -132,7 +132,7 @@ class GraphUser extends GraphNode
      *
      * @return null|GraphPage
      */
-    public function getLocation()
+    public function getLocation(): ?GraphPage
     {
         return $this->getField('location');
     }
@@ -142,7 +142,7 @@ class GraphUser extends GraphNode
      *
      * @return null|GraphPage
      */
-    public function getHometown()
+    public function getHometown(): ?GraphPage
     {
         return $this->getField('hometown');
     }
@@ -152,7 +152,7 @@ class GraphUser extends GraphNode
      *
      * @return null|GraphUser
      */
-    public function getSignificantOther()
+    public function getSignificantOther(): ?GraphUser
     {
         return $this->getField('significant_other');
     }
@@ -162,7 +162,7 @@ class GraphUser extends GraphNode
      *
      * @return null|GraphPicture
      */
-    public function getPicture()
+    public function getPicture(): ?GraphPicture
     {
         return $this->getField('picture');
     }

--- a/src/Helper/CanvasHelper.php
+++ b/src/Helper/CanvasHelper.php
@@ -42,7 +42,7 @@ class CanvasHelper extends SignedRequestFromInputHelper
      *
      * @return null|string
      */
-    public function getRawSignedRequest()
+    public function getRawSignedRequest(): ?string
     {
         return $this->getRawSignedRequestFromPost() ?: null;
     }

--- a/src/Helper/JavaScriptHelper.php
+++ b/src/Helper/JavaScriptHelper.php
@@ -32,7 +32,7 @@ class JavaScriptHelper extends SignedRequestFromInputHelper
      *
      * @return null|string
      */
-    public function getRawSignedRequest()
+    public function getRawSignedRequest(): ?string
     {
         return $this->getRawSignedRequestFromCookie();
     }

--- a/src/Helper/PageTabHelper.php
+++ b/src/Helper/PageTabHelper.php
@@ -42,7 +42,7 @@ class PageTabHelper extends CanvasHelper
      * @param Client      $client       the client to make HTTP requests
      * @param string      $graphVersion the version of Graph to use
      */
-    public function __construct(Application $app, Client $client, $graphVersion)
+    public function __construct(Application $app, Client $client, string $graphVersion)
     {
         parent::__construct($app, $client, $graphVersion);
 
@@ -61,7 +61,7 @@ class PageTabHelper extends CanvasHelper
      *
      * @return null|mixed
      */
-    public function getPageData($key, $default = null)
+    public function getPageData(string $key, $default = null)
     {
         if (isset($this->pageData[$key])) {
             return $this->pageData[$key];
@@ -75,7 +75,7 @@ class PageTabHelper extends CanvasHelper
      *
      * @return bool
      */
-    public function isAdmin()
+    public function isAdmin(): bool
     {
         return $this->getPageData('admin') === true;
     }
@@ -85,7 +85,7 @@ class PageTabHelper extends CanvasHelper
      *
      * @return null|string
      */
-    public function getPageId()
+    public function getPageId(): ?string
     {
         return $this->getPageData('id');
     }

--- a/src/Helper/RedirectLoginHelper.php
+++ b/src/Helper/RedirectLoginHelper.php
@@ -61,8 +61,11 @@ class RedirectLoginHelper
      * @param null|PersistentDataInterface $persistentDataHandler the persistent data handler
      * @param null|UrlDetectionInterface   $urlHandler            the URL detection handler
      */
-    public function __construct(OAuth2Client $oAuth2Client, PersistentDataInterface $persistentDataHandler = null, UrlDetectionInterface $urlHandler = null)
-    {
+    public function __construct(
+        OAuth2Client $oAuth2Client,
+        ?PersistentDataInterface $persistentDataHandler = null,
+        ?UrlDetectionInterface $urlHandler = null
+    ) {
         $this->oAuth2Client = $oAuth2Client;
         $this->persistentDataHandler = $persistentDataHandler ?: new SessionPersistentDataHandler();
         $this->urlDetectionHandler = $urlHandler ?: new UrlDetectionHandler();
@@ -73,7 +76,7 @@ class RedirectLoginHelper
      *
      * @return PersistentDataInterface
      */
-    public function getPersistentDataHandler()
+    public function getPersistentDataHandler(): PersistentDataInterface
     {
         return $this->persistentDataHandler;
     }
@@ -83,7 +86,7 @@ class RedirectLoginHelper
      *
      * @return UrlDetectionInterface
      */
-    public function getUrlDetectionHandler()
+    public function getUrlDetectionHandler(): UrlDetectionInterface
     {
         return $this->urlDetectionHandler;
     }
@@ -98,7 +101,7 @@ class RedirectLoginHelper
      *
      * @return string
      */
-    private function makeUrl($redirectUrl, array $scope, array $params = [], $separator = '&')
+    private function makeUrl(string $redirectUrl, array $scope, array $params = [], string $separator = '&'): string
     {
         $state = $this->persistentDataHandler->get('state') ?: $this->getPseudoRandomString();
         $this->persistentDataHandler->set('state', $state);
@@ -106,7 +109,7 @@ class RedirectLoginHelper
         return $this->oAuth2Client->getAuthorizationUrl($redirectUrl, $state, $scope, $params, $separator);
     }
 
-    private function getPseudoRandomString()
+    private function getPseudoRandomString(): string
     {
         return bin2hex(random_bytes(static::CSRF_LENGTH));
     }
@@ -120,7 +123,7 @@ class RedirectLoginHelper
      *
      * @return string
      */
-    public function getLoginUrl($redirectUrl, array $scope = [], $separator = '&')
+    public function getLoginUrl(string $redirectUrl, array $scope = [], string $separator = '&'): string
     {
         return $this->makeUrl($redirectUrl, $scope, [], $separator);
     }
@@ -136,7 +139,7 @@ class RedirectLoginHelper
      *
      * @return string
      */
-    public function getLogoutUrl($accessToken, $next, $separator = '&')
+    public function getLogoutUrl($accessToken, string $next, string $separator = '&')
     {
         if (!$accessToken instanceof AccessToken) {
             $accessToken = new AccessToken($accessToken);
@@ -163,7 +166,7 @@ class RedirectLoginHelper
      *
      * @return string
      */
-    public function getReRequestUrl($redirectUrl, array $scope = [], $separator = '&')
+    public function getReRequestUrl(string $redirectUrl, array $scope = [], string $separator = '&'): string
     {
         $params = ['auth_type' => 'rerequest'];
 
@@ -179,7 +182,7 @@ class RedirectLoginHelper
      *
      * @return string
      */
-    public function getReAuthenticationUrl($redirectUrl, array $scope = [], $separator = '&')
+    public function getReAuthenticationUrl(string $redirectUrl, array $scope = [], string $separator = '&'): string
     {
         $params = ['auth_type' => 'reauthenticate'];
 
@@ -193,9 +196,9 @@ class RedirectLoginHelper
      *
      * @throws SDKException
      *
-     * @return null|AccessToken
+     * @return null|string|AccessToken
      */
-    public function getAccessToken($redirectUrl = null)
+    public function getAccessToken(?string $redirectUrl = null)
     {
         if (!$code = $this->getCode()) {
             return null;
@@ -216,7 +219,7 @@ class RedirectLoginHelper
      *
      * @throws SDKException
      */
-    protected function validateCsrf()
+    protected function validateCsrf(): void
     {
         $state = $this->getState();
         if (!$state) {
@@ -237,7 +240,7 @@ class RedirectLoginHelper
     /**
      * Resets the CSRF so that it doesn't get reused.
      */
-    private function resetCsrf()
+    private function resetCsrf(): void
     {
         $this->persistentDataHandler->set('state', null);
     }
@@ -247,7 +250,7 @@ class RedirectLoginHelper
      *
      * @return null|string
      */
-    protected function getCode()
+    protected function getCode(): ?string
     {
         return $this->getInput('code');
     }
@@ -257,7 +260,7 @@ class RedirectLoginHelper
      *
      * @return null|string
      */
-    protected function getState()
+    protected function getState(): ?string
     {
         return $this->getInput('state');
     }
@@ -267,7 +270,7 @@ class RedirectLoginHelper
      *
      * @return null|string
      */
-    public function getErrorCode()
+    public function getErrorCode(): ?string
     {
         return $this->getInput('error_code');
     }
@@ -277,7 +280,7 @@ class RedirectLoginHelper
      *
      * @return null|string
      */
-    public function getError()
+    public function getError(): ?string
     {
         return $this->getInput('error');
     }
@@ -287,7 +290,7 @@ class RedirectLoginHelper
      *
      * @return null|string
      */
-    public function getErrorReason()
+    public function getErrorReason(): ?string
     {
         return $this->getInput('error_reason');
     }
@@ -297,7 +300,7 @@ class RedirectLoginHelper
      *
      * @return null|string
      */
-    public function getErrorDescription()
+    public function getErrorDescription(): ?string
     {
         return $this->getInput('error_description');
     }
@@ -309,7 +312,7 @@ class RedirectLoginHelper
      *
      * @return null|string
      */
-    private function getInput($key)
+    private function getInput(string $key): ?string
     {
         return $_GET[$key] ?? null;
     }

--- a/src/Helper/SignedRequestFromInputHelper.php
+++ b/src/Helper/SignedRequestFromInputHelper.php
@@ -56,7 +56,7 @@ abstract class SignedRequestFromInputHelper
      * @param Client      $client       the client to make HTTP requests
      * @param string      $graphVersion the version of Graph to use
      */
-    public function __construct(Application $app, Client $client, $graphVersion)
+    public function __construct(Application $app, Client $client, string $graphVersion)
     {
         $this->app = $app;
         $this->oAuth2Client = new OAuth2Client($this->app, $client, $graphVersion);
@@ -70,7 +70,7 @@ abstract class SignedRequestFromInputHelper
      * @param null|string
      * @param null|mixed $rawSignedRequest
      */
-    public function instantiateSignedRequest($rawSignedRequest = null)
+    public function instantiateSignedRequest(?string $rawSignedRequest = null)
     {
         $rawSignedRequest = $rawSignedRequest ?: $this->getRawSignedRequest();
 
@@ -88,7 +88,7 @@ abstract class SignedRequestFromInputHelper
      *
      * @return null|AccessToken
      */
-    public function getAccessToken()
+    public function getAccessToken(): ?AccessToken
     {
         if ($this->signedRequest && $this->signedRequest->hasOAuthData()) {
             $code = $this->signedRequest->get('code');
@@ -111,7 +111,7 @@ abstract class SignedRequestFromInputHelper
      *
      * @return null|SignedRequest
      */
-    public function getSignedRequest()
+    public function getSignedRequest(): ?SignedRequest
     {
         return $this->signedRequest;
     }
@@ -121,7 +121,7 @@ abstract class SignedRequestFromInputHelper
      *
      * @return null|string
      */
-    public function getUserId()
+    public function getUserId(): ?string
     {
         return $this->signedRequest ? $this->signedRequest->getUserId() : null;
     }
@@ -131,14 +131,14 @@ abstract class SignedRequestFromInputHelper
      *
      * @return null|string
      */
-    abstract public function getRawSignedRequest();
+    abstract public function getRawSignedRequest(): ?string;
 
     /**
      * Get raw signed request from POST input.
      *
      * @return null|string
      */
-    public function getRawSignedRequestFromPost()
+    public function getRawSignedRequestFromPost(): ?string
     {
         if (isset($_POST['signed_request'])) {
             return $_POST['signed_request'];
@@ -152,7 +152,7 @@ abstract class SignedRequestFromInputHelper
      *
      * @return null|string
      */
-    public function getRawSignedRequestFromCookie()
+    public function getRawSignedRequestFromCookie(): ?string
     {
         if (isset($_COOKIE['fbsr_' . $this->app->getId()])) {
             return $_COOKIE['fbsr_' . $this->app->getId()];

--- a/src/Http/RequestBodyInterface.php
+++ b/src/Http/RequestBodyInterface.php
@@ -32,5 +32,5 @@ interface RequestBodyInterface
      *
      * @return string
      */
-    public function getBody();
+    public function getBody(): string;
 }

--- a/src/Http/RequestBodyMultipart.php
+++ b/src/Http/RequestBodyMultipart.php
@@ -63,7 +63,7 @@ class RequestBodyMultipart implements RequestBodyInterface
     /**
      * {@inheritdoc}
      */
-    public function getBody()
+    public function getBody(): string
     {
         $body = '';
 
@@ -89,7 +89,7 @@ class RequestBodyMultipart implements RequestBodyInterface
      *
      * @return string
      */
-    public function getBoundary()
+    public function getBoundary(): string
     {
         return $this->boundary;
     }
@@ -102,7 +102,7 @@ class RequestBodyMultipart implements RequestBodyInterface
      *
      * @return string
      */
-    private function getFileString($name, File $file)
+    private function getFileString(string $name, File $file): string
     {
         return sprintf(
             "--%s\r\nContent-Disposition: form-data; name=\"%s\"; filename=\"%s\"%s\r\n\r\n%s\r\n",
@@ -122,7 +122,7 @@ class RequestBodyMultipart implements RequestBodyInterface
      *
      * @return string
      */
-    private function getParamString($name, $value)
+    private function getParamString(string $name, string $value): string
     {
         return sprintf(
             "--%s\r\nContent-Disposition: form-data; name=\"%s\"\r\n\r\n%s\r\n",
@@ -139,7 +139,7 @@ class RequestBodyMultipart implements RequestBodyInterface
      *
      * @return array
      */
-    private function getNestedParams(array $params)
+    private function getNestedParams(array $params): array
     {
         $query = http_build_query($params, null, '&');
         $params = explode('&', $query);
@@ -160,7 +160,7 @@ class RequestBodyMultipart implements RequestBodyInterface
      *
      * @return string
      */
-    protected function getFileHeaders(File $file)
+    protected function getFileHeaders(File $file): string
     {
         return "\r\nContent-Type: {$file->getMimetype()}";
     }

--- a/src/Http/RequestBodyUrlEncoded.php
+++ b/src/Http/RequestBodyUrlEncoded.php
@@ -45,7 +45,7 @@ class RequestBodyUrlEncoded implements RequestBodyInterface
     /**
      * {@inheritdoc}
      */
-    public function getBody()
+    public function getBody(): string
     {
         return http_build_query($this->params, null, '&');
     }

--- a/src/PersistentData/InMemoryPersistentDataHandler.php
+++ b/src/PersistentData/InMemoryPersistentDataHandler.php
@@ -35,7 +35,7 @@ class InMemoryPersistentDataHandler implements PersistentDataInterface
     /**
      * {@inheritdoc}
      */
-    public function get($key)
+    public function get(string $key)
     {
         return $this->sessionData[$key] ?? null;
     }
@@ -43,7 +43,7 @@ class InMemoryPersistentDataHandler implements PersistentDataInterface
     /**
      * {@inheritdoc}
      */
-    public function set($key, $value)
+    public function set(string $key, $value): void
     {
         $this->sessionData[$key] = $value;
     }

--- a/src/PersistentData/PersistentDataFactory.php
+++ b/src/PersistentData/PersistentDataFactory.php
@@ -40,7 +40,7 @@ class PersistentDataFactory
      *
      * @return PersistentDataInterface
      */
-    public static function createPersistentDataHandler($handler)
+    public static function createPersistentDataHandler($handler): PersistentDataInterface
     {
         if (!$handler) {
             return session_status() === PHP_SESSION_ACTIVE

--- a/src/PersistentData/PersistentDataInterface.php
+++ b/src/PersistentData/PersistentDataInterface.php
@@ -34,7 +34,7 @@ interface PersistentDataInterface
      *
      * @return mixed
      */
-    public function get($key);
+    public function get(string $key);
 
     /**
      * Set a value in the persistent data store.
@@ -42,5 +42,5 @@ interface PersistentDataInterface
      * @param string $key
      * @param mixed  $value
      */
-    public function set($key, $value);
+    public function set(string $key, $value): void;
 }

--- a/src/PersistentData/SessionPersistentDataHandler.php
+++ b/src/PersistentData/SessionPersistentDataHandler.php
@@ -41,7 +41,7 @@ class SessionPersistentDataHandler implements PersistentDataInterface
      *
      * @throws SDKException
      */
-    public function __construct($enableSessionCheck = true)
+    public function __construct(bool $enableSessionCheck = true)
     {
         if ($enableSessionCheck && session_status() !== PHP_SESSION_ACTIVE) {
             throw new SDKException(
@@ -54,7 +54,7 @@ class SessionPersistentDataHandler implements PersistentDataInterface
     /**
      * {@inheritdoc}
      */
-    public function get($key)
+    public function get(string $key)
     {
         if (isset($_SESSION[$this->sessionPrefix . $key])) {
             return $_SESSION[$this->sessionPrefix . $key];
@@ -66,7 +66,7 @@ class SessionPersistentDataHandler implements PersistentDataInterface
     /**
      * {@inheritdoc}
      */
-    public function set($key, $value)
+    public function set(string $key, $value): void
     {
         $_SESSION[$this->sessionPrefix . $key] = $value;
     }

--- a/src/Request.php
+++ b/src/Request.php
@@ -87,14 +87,21 @@ class Request
      *
      * @param null|Application        $app
      * @param null|AccessToken|string $accessToken
-     * @param null|string             $method
-     * @param null|string             $endpoint
-     * @param null|array              $params
-     * @param null|string             $eTag
+     * @param string             $method
+     * @param string             $endpoint
+     * @param array              $params
+     * @param string             $eTag
      * @param null|string             $graphVersion
      */
-    public function __construct(Application $app = null, $accessToken = null, $method = null, $endpoint = null, array $params = [], $eTag = null, $graphVersion = null)
-    {
+    public function __construct(
+        Application $app = null,
+        $accessToken = null,
+        string $method = "",
+        string $endpoint = "",
+        array $params = [],
+        string $eTag = "",
+        ?string $graphVersion = null
+    ) {
         $this->setApp($app);
         $this->setAccessToken($accessToken);
         $this->setMethod($method);
@@ -107,12 +114,11 @@ class Request
     /**
      * Set the access token for this request.
      *
-     * @param null|AccessToken|string
-     * @param mixed $accessToken
+     * @param null|AccessToken|string $accessToken
      *
      * @return Request
      */
-    public function setAccessToken($accessToken)
+    public function setAccessToken($accessToken): Request
     {
         $this->accessToken = $accessToken;
         if ($accessToken instanceof AccessToken) {
@@ -131,7 +137,7 @@ class Request
      *
      * @return Request
      */
-    public function setAccessTokenFromParams($accessToken)
+    public function setAccessTokenFromParams($accessToken): Request
     {
         $existingAccessToken = $this->getAccessToken();
         if (!$existingAccessToken) {
@@ -148,7 +154,7 @@ class Request
      *
      * @return null|string
      */
-    public function getAccessToken()
+    public function getAccessToken(): ?string
     {
         return $this->accessToken;
     }
@@ -158,7 +164,7 @@ class Request
      *
      * @return null|AccessToken
      */
-    public function getAccessTokenEntity()
+    public function getAccessTokenEntity(): ?AccessToken
     {
         return $this->accessToken ? new AccessToken($this->accessToken) : null;
     }
@@ -168,7 +174,7 @@ class Request
      *
      * @param null|Application $app
      */
-    public function setApp(Application $app = null)
+    public function setApp(?Application $app = null): void
     {
         $this->app = $app;
     }
@@ -176,9 +182,9 @@ class Request
     /**
      * Return the Application entity used for this request.
      *
-     * @return Application
+     * @return null|Application
      */
-    public function getApplication()
+    public function getApplication(): ?Application
     {
         return $this->app;
     }
@@ -188,7 +194,7 @@ class Request
      *
      * @return null|string
      */
-    public function getAppSecretProof()
+    public function getAppSecretProof(): ?string
     {
         if (!$accessTokenEntity = $this->getAccessTokenEntity()) {
             return null;
@@ -202,7 +208,7 @@ class Request
      *
      * @throws SDKException
      */
-    public function validateAccessToken()
+    public function validateAccessToken(): void
     {
         $accessToken = $this->getAccessToken();
         if (!$accessToken) {
@@ -213,10 +219,9 @@ class Request
     /**
      * Set the HTTP method for this request.
      *
-     * @param string
-     * @param mixed $method
+     * @param string $method
      */
-    public function setMethod($method)
+    public function setMethod(string $method): void
     {
         $this->method = strtoupper($method);
     }
@@ -226,7 +231,7 @@ class Request
      *
      * @return string
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -236,7 +241,7 @@ class Request
      *
      * @throws SDKException
      */
-    public function validateMethod()
+    public function validateMethod(): void
     {
         if (!$this->method) {
             throw new SDKException('HTTP method not specified.');
@@ -250,14 +255,13 @@ class Request
     /**
      * Set the endpoint for this request.
      *
-     * @param string
-     * @param mixed $endpoint
+     * @param string $endpoint
      *
      * @throws SDKException
      *
      * @return Request
      */
-    public function setEndpoint($endpoint)
+    public function setEndpoint(string $endpoint): Request
     {
         // Harvest the access token from the endpoint to keep things in sync
         $params = UrlManipulator::getParamsAsArray($endpoint);
@@ -277,7 +281,7 @@ class Request
      *
      * @return string
      */
-    public function getEndpoint()
+    public function getEndpoint(): string
     {
         // For batch requests, this will be empty
         return $this->endpoint;
@@ -288,7 +292,7 @@ class Request
      *
      * @return array
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         $headers = static::getDefaultHeaders();
 
@@ -304,7 +308,7 @@ class Request
      *
      * @param array $headers
      */
-    public function setHeaders(array $headers)
+    public function setHeaders(array $headers): void
     {
         $this->headers = array_merge($this->headers, $headers);
     }
@@ -314,7 +318,7 @@ class Request
      *
      * @param string $eTag
      */
-    public function setETag($eTag)
+    public function setETag(string $eTag): void
     {
         $this->eTag = $eTag;
     }
@@ -328,7 +332,7 @@ class Request
      *
      * @return Request
      */
-    public function setParams(array $params = [])
+    public function setParams(array $params = []): Request
     {
         if (isset($params['access_token'])) {
             $this->setAccessTokenFromParams($params['access_token']);
@@ -352,7 +356,7 @@ class Request
      *
      * @return Request
      */
-    public function dangerouslySetParams(array $params = [])
+    public function dangerouslySetParams(array $params = []): Request
     {
         $this->params = array_merge($this->params, $params);
 
@@ -366,7 +370,7 @@ class Request
      *
      * @return array
      */
-    public function sanitizeFileParams(array $params)
+    public function sanitizeFileParams(array $params): array
     {
         foreach ($params as $key => $value) {
             if ($value instanceof File) {
@@ -384,7 +388,7 @@ class Request
      * @param string $key
      * @param File   $file
      */
-    public function addFile($key, File $file)
+    public function addFile(string $key, File $file): void
     {
         $this->files[$key] = $file;
     }
@@ -392,7 +396,7 @@ class Request
     /**
      * Removes all the files from the upload queue.
      */
-    public function resetFiles()
+    public function resetFiles(): void
     {
         $this->files = [];
     }
@@ -402,7 +406,7 @@ class Request
      *
      * @return array
      */
-    public function getFiles()
+    public function getFiles(): array
     {
         return $this->files;
     }
@@ -412,7 +416,7 @@ class Request
      *
      * @return bool
      */
-    public function containsFileUploads()
+    public function containsFileUploads(): bool
     {
         return !empty($this->files);
     }
@@ -422,7 +426,7 @@ class Request
      *
      * @return bool
      */
-    public function containsVideoUploads()
+    public function containsVideoUploads(): bool
     {
         foreach ($this->files as $file) {
             if ($file instanceof Video) {
@@ -438,7 +442,7 @@ class Request
      *
      * @return RequestBodyMultipart
      */
-    public function getMultipartBody()
+    public function getMultipartBody(): RequestBodyMultipart
     {
         $params = $this->getPostParams();
 
@@ -450,7 +454,7 @@ class Request
      *
      * @return RequestBodyUrlEncoded
      */
-    public function getUrlEncodedBody()
+    public function getUrlEncodedBody(): RequestBodyUrlEncoded
     {
         $params = $this->getPostParams();
 
@@ -462,7 +466,7 @@ class Request
      *
      * @return array
      */
-    public function getParams()
+    public function getParams(): array
     {
         $params = $this->params;
 
@@ -480,7 +484,7 @@ class Request
      *
      * @return array
      */
-    public function getPostParams()
+    public function getPostParams(): array
     {
         if ($this->getMethod() === 'POST') {
             return $this->getParams();
@@ -494,7 +498,7 @@ class Request
      *
      * @return null|string
      */
-    public function getGraphVersion()
+    public function getGraphVersion(): ?string
     {
         return $this->graphVersion;
     }
@@ -504,7 +508,7 @@ class Request
      *
      * @return string
      */
-    public function getUrl()
+    public function getUrl(): string
     {
         $this->validateMethod();
 
@@ -526,7 +530,7 @@ class Request
      *
      * @return array
      */
-    public static function getDefaultHeaders()
+    public static function getDefaultHeaders(): array
     {
         return [
             'User-Agent' => 'fb-php-' . Facebook::VERSION,

--- a/src/Response.php
+++ b/src/Response.php
@@ -22,9 +22,18 @@
  */
 namespace Facebook;
 
+use Facebook\GraphNode\GraphAlbum;
+use Facebook\GraphNode\GraphEdge;
+use Facebook\GraphNode\GraphEvent;
+use Facebook\GraphNode\GraphGroup;
+use Facebook\GraphNode\GraphNode;
 use Facebook\GraphNode\GraphNodeFactory;
 use Facebook\Exception\ResponseException;
 use Facebook\Exception\SDKException;
+use Facebook\GraphNode\GraphPage;
+use Facebook\GraphNode\GraphSessionInfo;
+use Facebook\GraphNode\GraphUser;
+use Facebook\Http\RequestBodyUrlEncoded;
 
 /**
  * @package Facebook
@@ -67,10 +76,14 @@ class Response
      * @param Request     $request
      * @param null|string $body
      * @param null|int    $httpStatusCode
-     * @param null|array  $headers
+     * @param array  $headers
      */
-    public function __construct(Request $request, $body = null, $httpStatusCode = null, array $headers = [])
-    {
+    public function __construct(
+        Request $request,
+        ?string $body = null,
+        ?int $httpStatusCode = null,
+        array $headers = []
+    ) {
         $this->request = $request;
         $this->body = $body;
         $this->httpStatusCode = $httpStatusCode;
@@ -84,7 +97,7 @@ class Response
      *
      * @return Request
      */
-    public function getRequest()
+    public function getRequest(): Request
     {
         return $this->request;
     }
@@ -94,7 +107,7 @@ class Response
      *
      * @return Application
      */
-    public function getApplication()
+    public function getApplication(): Application
     {
         return $this->request->getApplication();
     }
@@ -104,7 +117,7 @@ class Response
      *
      * @return null|string
      */
-    public function getAccessToken()
+    public function getAccessToken(): ?string
     {
         return $this->request->getAccessToken();
     }
@@ -114,7 +127,7 @@ class Response
      *
      * @return int
      */
-    public function getHttpStatusCode()
+    public function getHttpStatusCode(): int
     {
         return $this->httpStatusCode;
     }
@@ -124,7 +137,7 @@ class Response
      *
      * @return array
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
@@ -134,7 +147,7 @@ class Response
      *
      * @return string
      */
-    public function getBody()
+    public function getBody(): string
     {
         return $this->body;
     }
@@ -144,7 +157,7 @@ class Response
      *
      * @return array
      */
-    public function getDecodedBody()
+    public function getDecodedBody(): array
     {
         return $this->decodedBody;
     }
@@ -154,7 +167,7 @@ class Response
      *
      * @return null|string
      */
-    public function getAppSecretProof()
+    public function getAppSecretProof(): ?string
     {
         return $this->request->getAppSecretProof();
     }
@@ -164,7 +177,7 @@ class Response
      *
      * @return null|string
      */
-    public function getETag()
+    public function getETag(): ?string
     {
         return $this->headers['ETag'] ?? null;
     }
@@ -174,7 +187,7 @@ class Response
      *
      * @return null|string
      */
-    public function getGraphVersion()
+    public function getGraphVersion(): ?string
     {
         return $this->headers['Facebook-API-Version'] ?? null;
     }
@@ -184,7 +197,7 @@ class Response
      *
      * @return bool
      */
-    public function isError()
+    public function isError(): bool
     {
         return isset($this->decodedBody['error']);
     }
@@ -194,7 +207,7 @@ class Response
      *
      * @throws SDKException
      */
-    public function throwException()
+    public function throwException(): void
     {
         throw $this->thrownException;
     }
@@ -202,7 +215,7 @@ class Response
     /**
      * Instantiates an exception to be thrown later.
      */
-    public function makeException()
+    public function makeException(): void
     {
         $this->thrownException = ResponseException::create($this);
     }
@@ -212,7 +225,7 @@ class Response
      *
      * @return null|ResponseException
      */
-    public function getThrownException()
+    public function getThrownException(): ?ResponseException
     {
         return $this->thrownException;
     }
@@ -228,7 +241,7 @@ class Response
      *    a short-lived access token for a long-lived access token
      * - And sometimes nothing :/ but that'd be a bug.
      */
-    public function decodeBody()
+    public function decodeBody(): void
     {
         $this->decodedBody = json_decode($this->body, true);
 
@@ -262,7 +275,7 @@ class Response
      *
      * @return \Facebook\GraphNode\GraphNode
      */
-    public function getGraphNode($subclassName = null)
+    public function getGraphNode(?string $subclassName = null): GraphNode
     {
         $factory = new GraphNodeFactory($this);
 
@@ -276,7 +289,7 @@ class Response
      *
      * @return \Facebook\GraphNode\GraphAlbum
      */
-    public function getGraphAlbum()
+    public function getGraphAlbum(): GraphAlbum
     {
         $factory = new GraphNodeFactory($this);
 
@@ -290,7 +303,7 @@ class Response
      *
      * @return \Facebook\GraphNode\GraphPage
      */
-    public function getGraphPage()
+    public function getGraphPage(): GraphPage
     {
         $factory = new GraphNodeFactory($this);
 
@@ -304,7 +317,7 @@ class Response
      *
      * @return \Facebook\GraphNode\GraphSessionInfo
      */
-    public function getGraphSessionInfo()
+    public function getGraphSessionInfo(): GraphSessionInfo
     {
         $factory = new GraphNodeFactory($this);
 
@@ -318,7 +331,7 @@ class Response
      *
      * @return \Facebook\GraphNode\GraphUser
      */
-    public function getGraphUser()
+    public function getGraphUser(): GraphUser
     {
         $factory = new GraphNodeFactory($this);
 
@@ -332,7 +345,7 @@ class Response
      *
      * @return \Facebook\GraphNode\GraphEvent
      */
-    public function getGraphEvent()
+    public function getGraphEvent(): GraphEvent
     {
         $factory = new GraphNodeFactory($this);
 
@@ -346,7 +359,7 @@ class Response
      *
      * @return \Facebook\GraphNode\GraphGroup
      */
-    public function getGraphGroup()
+    public function getGraphGroup(): GraphGroup
     {
         $factory = new GraphNodeFactory($this);
 
@@ -363,7 +376,7 @@ class Response
      *
      * @return \Facebook\GraphNode\GraphEdge
      */
-    public function getGraphEdge($subclassName = null, $auto_prefix = true)
+    public function getGraphEdge(?string $subclassName = null, bool $auto_prefix = true): GraphEdge
     {
         $factory = new GraphNodeFactory($this);
 

--- a/src/SignedRequest.php
+++ b/src/SignedRequest.php
@@ -50,7 +50,7 @@ class SignedRequest
      * @param Application $App              the Application entity
      * @param null|string $rawSignedRequest the raw signed request
      */
-    public function __construct(Application $App, $rawSignedRequest = null)
+    public function __construct(Application $App, ?string $rawSignedRequest = null)
     {
         $this->app = $App;
 
@@ -68,7 +68,7 @@ class SignedRequest
      *
      * @return null|string
      */
-    public function getRawSignedRequest()
+    public function getRawSignedRequest(): ?string
     {
         return $this->rawSignedRequest;
     }
@@ -78,7 +78,7 @@ class SignedRequest
      *
      * @return null|array
      */
-    public function getPayload()
+    public function getPayload(): ?array
     {
         return $this->payload;
     }
@@ -91,7 +91,7 @@ class SignedRequest
      *
      * @return null|mixed
      */
-    public function get($key, $default = null)
+    public function get(string $key, $default = null)
     {
         if (isset($this->payload[$key])) {
             return $this->payload[$key];
@@ -105,7 +105,7 @@ class SignedRequest
      *
      * @return null|string
      */
-    public function getUserId()
+    public function getUserId(): ?string
     {
         return $this->get('user_id');
     }
@@ -115,7 +115,7 @@ class SignedRequest
      *
      * @return bool
      */
-    public function hasOAuthData()
+    public function hasOAuthData(): bool
     {
         return $this->get('oauth_token') || $this->get('code');
     }
@@ -127,7 +127,7 @@ class SignedRequest
      *
      * @return string
      */
-    public function make(array $payload)
+    public function make(array $payload): string
     {
         $payload['algorithm'] = $payload['algorithm'] ?? 'HMAC-SHA256';
         $payload['issued_at'] = $payload['issued_at'] ?? time();
@@ -143,7 +143,7 @@ class SignedRequest
      * Validates and decodes a signed request and saves
      * the payload to an array.
      */
-    protected function parse()
+    protected function parse(): void
     {
         list($encodedSig, $encodedPayload) = $this->split();
 
@@ -165,7 +165,7 @@ class SignedRequest
      *
      * @return array
      */
-    protected function split()
+    protected function split(): array
     {
         if (strpos($this->rawSignedRequest, '.') === false) {
             throw new SDKException('Malformed signed request.', 606);
@@ -183,7 +183,7 @@ class SignedRequest
      *
      * @return string
      */
-    protected function decodeSignature($encodedSig)
+    protected function decodeSignature(string $encodedSig): string
     {
         $sig = $this->base64UrlDecode($encodedSig);
 
@@ -203,7 +203,7 @@ class SignedRequest
      *
      * @return array
      */
-    protected function decodePayload($encodedPayload)
+    protected function decodePayload(string $encodedPayload): array
     {
         $payload = $this->base64UrlDecode($encodedPayload);
 
@@ -223,7 +223,7 @@ class SignedRequest
      *
      * @throws SDKException
      */
-    protected function validateAlgorithm()
+    protected function validateAlgorithm(): void
     {
         if ($this->get('algorithm') !== 'HMAC-SHA256') {
             throw new SDKException('Signed request is using the wrong algorithm.', 605);
@@ -239,7 +239,7 @@ class SignedRequest
      *
      * @return string
      */
-    protected function hashSignature($encodedData)
+    protected function hashSignature(string $encodedData): string
     {
         $hashedSig = hash_hmac(
             'sha256',
@@ -263,7 +263,7 @@ class SignedRequest
      *
      * @throws SDKException
      */
-    protected function validateSignature($hashedSig, $sig)
+    protected function validateSignature(string $hashedSig, string $sig): void
     {
         if (\hash_equals($hashedSig, $sig)) {
             return;
@@ -283,7 +283,7 @@ class SignedRequest
      *
      * @return string decoded string
      */
-    public function base64UrlDecode($input)
+    public function base64UrlDecode(string $input): string
     {
         $urlDecodedBase64 = strtr($input, '-_', '+/');
         $this->validateBase64($urlDecodedBase64);
@@ -302,7 +302,7 @@ class SignedRequest
      *
      * @return string base64 url encoded input
      */
-    public function base64UrlEncode($input)
+    public function base64UrlEncode(string $input): string
     {
         return strtr(base64_encode($input), '+/', '-_');
     }
@@ -314,7 +314,7 @@ class SignedRequest
      *
      * @throws SDKException
      */
-    protected function validateBase64($input)
+    protected function validateBase64(string $input): void
     {
         if (!preg_match('/^[a-zA-Z0-9\/\r\n+]*={0,2}$/', $input)) {
             throw new SDKException('Signed request contains malformed base64 encoding.', 608);

--- a/src/Url/UrlDetectionHandler.php
+++ b/src/Url/UrlDetectionHandler.php
@@ -30,7 +30,7 @@ class UrlDetectionHandler implements UrlDetectionInterface
     /**
      * {@inheritdoc}
      */
-    public function getCurrentUrl()
+    public function getCurrentUrl(): string
     {
         return $this->getHttpScheme() . '://' . $this->getHostName() . $this->getServerVar('REQUEST_URI');
     }
@@ -40,7 +40,7 @@ class UrlDetectionHandler implements UrlDetectionInterface
      *
      * @return string
      */
-    protected function getHttpScheme()
+    protected function getHttpScheme(): string
     {
         return $this->isBehindSsl() ? 'https' : 'http';
     }
@@ -50,7 +50,7 @@ class UrlDetectionHandler implements UrlDetectionInterface
      *
      * @return bool
      */
-    protected function isBehindSsl()
+    protected function isBehindSsl(): bool
     {
         // Check for proxy first
         $protocol = $this->getHeader('X_FORWARDED_PROTO');
@@ -73,7 +73,7 @@ class UrlDetectionHandler implements UrlDetectionInterface
      *
      * @return bool
      */
-    protected function protocolWithActiveSsl($protocol)
+    protected function protocolWithActiveSsl(string $protocol): bool
     {
         $protocol = strtolower((string)$protocol);
 
@@ -89,7 +89,7 @@ class UrlDetectionHandler implements UrlDetectionInterface
      *
      * @return string
      */
-    protected function getHostName()
+    protected function getHostName(): string
     {
         // Check for proxy first
         $header = $this->getHeader('X_FORWARDED_HOST');
@@ -119,6 +119,9 @@ class UrlDetectionHandler implements UrlDetectionInterface
         return $host . $appendPort;
     }
 
+    /**
+     * @return string|int
+     */
     protected function getCurrentPort()
     {
         // Check for proxy first
@@ -142,7 +145,7 @@ class UrlDetectionHandler implements UrlDetectionInterface
      *
      * @return string
      */
-    protected function getServerVar($key)
+    protected function getServerVar(string $key): string
     {
         return $_SERVER[$key] ?? '';
     }
@@ -154,7 +157,7 @@ class UrlDetectionHandler implements UrlDetectionInterface
      *
      * @return string
      */
-    protected function getHeader($key)
+    protected function getHeader(string $key): string
     {
         return $this->getServerVar('HTTP_' . $key);
     }
@@ -167,7 +170,7 @@ class UrlDetectionHandler implements UrlDetectionInterface
      *
      * @return bool
      */
-    protected function isValidForwardedHost($header)
+    protected function isValidForwardedHost(string $header): bool
     {
         $elements = explode(',', $header);
         $host = $elements[count($elements) - 1];

--- a/src/Url/UrlDetectionInterface.php
+++ b/src/Url/UrlDetectionInterface.php
@@ -32,5 +32,5 @@ interface UrlDetectionInterface
      *
      * @return string
      */
-    public function getCurrentUrl();
+    public function getCurrentUrl(): string;
 }

--- a/src/Url/UrlManipulator.php
+++ b/src/Url/UrlManipulator.php
@@ -35,7 +35,7 @@ class UrlManipulator
      *
      * @return string the URL with the params removed
      */
-    public static function removeParamsFromUrl($url, array $paramsToFilter)
+    public static function removeParamsFromUrl(string $url, array $paramsToFilter): string
     {
         $parts = parse_url($url);
 
@@ -71,7 +71,7 @@ class UrlManipulator
      *
      * @return string
      */
-    public static function appendParamsToUrl($url, array $newParams = [])
+    public static function appendParamsToUrl(string $url, array $newParams = []): string
     {
         if (empty($newParams)) {
             return $url;
@@ -101,7 +101,7 @@ class UrlManipulator
      *
      * @return array
      */
-    public static function getParamsAsArray($url)
+    public static function getParamsAsArray(string $url): array
     {
         $query = parse_url($url, PHP_URL_QUERY);
         if (!$query) {
@@ -123,7 +123,7 @@ class UrlManipulator
      *
      * @return string the $urlToAddTo with any new params from $urlToStealFrom
      */
-    public static function mergeUrlParams($urlToStealFrom, $urlToAddTo)
+    public static function mergeUrlParams(string $urlToStealFrom, string $urlToAddTo): string
     {
         $newParams = static::getParamsAsArray($urlToStealFrom);
         // Nothing new to add, return as-is
@@ -141,7 +141,7 @@ class UrlManipulator
      *
      * @return string
      */
-    public static function forceSlashPrefix($string)
+    public static function forceSlashPrefix(?string $string): string
     {
         if (!$string) {
             return '';
@@ -157,7 +157,7 @@ class UrlManipulator
      *
      * @return string the $urlToTrim with the hostname and Graph version removed
      */
-    public static function baseGraphUrlEndpoint($urlToTrim)
+    public static function baseGraphUrlEndpoint(string $urlToTrim): string
     {
         return '/' . preg_replace('/^https:\/\/.+\.facebook\.com(\/v.+?)?\//', '', $urlToTrim);
     }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -66,9 +66,10 @@ class ApplicationTest extends TestCase
     }
 
     /**
+     * TODO Delete as with types this is automatically coerced to string
      * @expectedException \Facebook\Exception\SDKException
      */
-    public function testOverflowIntegersWillThrow()
+    /*public function testOverflowIntegersWillThrow()
     {
         new Application(PHP_INT_MAX + 1, "foo");
     }
@@ -78,5 +79,5 @@ class ApplicationTest extends TestCase
         $newApp = unserialize(serialize(new Application(1, "foo")));
 
         $this->assertSame('1', $newApp->getId());
-    }
+    }*/
 }

--- a/tests/Authentication/FooClientForOAuth2Test.php
+++ b/tests/Authentication/FooClientForOAuth2Test.php
@@ -45,7 +45,7 @@ class FooClientForOAuth2Test extends Client
         $this->response = '{"code":"my_neat_code"}';
     }
 
-    public function sendRequest(Request $request)
+    public function sendRequest(Request $request): Response
     {
         return new Response(
             $request,

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -287,7 +287,7 @@ class Test extends TestCase
           'http_client' => new FakeGraphApiForResumableUpload(),
         ]);
         $fb = new Facebook($config);
-        $response = $fb->uploadVideo('me', __DIR__.'/foo.txt', [], 'foo-token', 3);
+        $response = $fb->uploadVideo(1337, __DIR__.'/foo.txt', [], 'foo-token', 3);
         $this->assertEquals([
           'video_id' => '1337',
           'success' => true,

--- a/tests/Fixtures/FooPersistentDataInterface.php
+++ b/tests/Fixtures/FooPersistentDataInterface.php
@@ -26,12 +26,12 @@ use Facebook\PersistentData\PersistentDataInterface;
 
 class FooPersistentDataInterface implements PersistentDataInterface
 {
-    public function get($key)
+    public function get(string $key)
     {
         return 'foo';
     }
 
-    public function set($key, $value)
+    public function set(string $key, $value): void
     {
     }
 }

--- a/tests/Fixtures/FooRedirectLoginOAuth2Client.php
+++ b/tests/Fixtures/FooRedirectLoginOAuth2Client.php
@@ -26,7 +26,7 @@ use Facebook\Authentication\OAuth2Client;
 
 class FooRedirectLoginOAuth2Client extends OAuth2Client
 {
-    public function getAccessTokenFromCode($code, $redirectUri = '', $machineId = null)
+    public function getAccessTokenFromCode(string $code, string $redirectUri = '', $machineId = null): string
     {
         return 'foo_token_from_code|' . $code . '|' . $redirectUri;
     }

--- a/tests/Fixtures/FooSignedRequestHelper.php
+++ b/tests/Fixtures/FooSignedRequestHelper.php
@@ -26,7 +26,7 @@ use Facebook\Helper\SignedRequestFromInputHelper;
 
 class FooSignedRequestHelper extends SignedRequestFromInputHelper
 {
-    public function getRawSignedRequest()
+    public function getRawSignedRequest(): ?string
     {
         return null;
     }

--- a/tests/Fixtures/FooSignedRequestHelperClient.php
+++ b/tests/Fixtures/FooSignedRequestHelperClient.php
@@ -28,7 +28,7 @@ use Facebook\Response;
 
 class FooSignedRequestHelperClient extends Client
 {
-    public function sendRequest(Request $request)
+    public function sendRequest(Request $request): Response
     {
         $params = $request->getParams();
         $rawResponse = json_encode([

--- a/tests/Fixtures/FooUrlDetectionInterface.php
+++ b/tests/Fixtures/FooUrlDetectionInterface.php
@@ -26,7 +26,7 @@ use Facebook\Url\UrlDetectionInterface;
 
 class FooUrlDetectionInterface implements UrlDetectionInterface
 {
-    public function getCurrentUrl()
+    public function getCurrentUrl(): string
     {
         return 'https://foo.bar';
     }

--- a/tests/GraphNode/GraphEdgeTest.php
+++ b/tests/GraphNode/GraphEdgeTest.php
@@ -160,7 +160,8 @@ class GraphEdgeTest extends TestCase
     public function testTheKeysFromTheCollectionCanBeReturned()
     {
         $graphEdge = new GraphEdge(
-            $this->request, [
+            $this->request,
+            [
                 'key1' => 'foo',
                 'key2' => 'bar',
                 'key3' => 'baz',

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -128,7 +128,7 @@ class RequestTest extends TestCase
 
         $this->assertEquals($expectedUrl, $getUrl);
 
-        $postRequest = new Request($app, 'foo_token', 'POST', '/bar', ['foo' => 'bar'], null, 'v0.0');
+        $postRequest = new Request($app, 'foo_token', 'POST', '/bar', ['foo' => 'bar'], '', 'v0.0');
 
         $postUrl = $postRequest->getUrl();
         $expectedUrl = '/v0.0/bar';


### PR DESCRIPTION
Added parameter type hints and return types when possible.
To do so needed to change all ETags to empty strings and stop
accepting NULL, same for some other parameters used in the
constructor of Facebook\Request

Most of these are based on the doc blocks and adjustement made for tests to pass green (other than the recurring ``Facebook\Tests\Test::testPaginationReturnsProperResponse`` test failure which seems to be related to some Graph API changes on Facebook's side.