### PR TITLE
[6.0] Use PSR 17 and 18 standard. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,15 @@
     },
     "require": {
         "php": "^7.1",
-        "psr/http-message": "^1.0",
-        "php-http/client-implementation": "^1.0",
-        "php-http/httplug": "^1.0",
-        "php-http/discovery": "^1.0",
-
-        "php-http/message": "^1.0"
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
-        "php-http/guzzle6-adapter": "^1.0"
+        "guzzlehttp/psr7": "^1.6",
+        "http-interop/http-factory-guzzle": "^1.0",
+        "ricardofiorani/guzzle-psr18-adapter": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -30,14 +30,20 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 > **Warning:** This assumes you have already created and configured a Facebook App, which you can obtain from the [App Dashboard](https://developers.facebook.com/apps).
 
-Before we can send requests to the Graph API, we need to load our app configuration into the `Facebook\Facebook` service.
+Before we can send requests to the Graph API, we need to load our app configuration into the `Facebook\Facebook`
+service with the necessary dependencies.
 
 ```php
-$fb = new Facebook\Facebook([
-  'app_id' => '{app-id}',
-  'app_secret' => '{app-secret}',
-  'default_graph_version' => 'v2.10',
-  ]);
+$fb = new Facebook\Facebook(
+    $client,
+    $requestFactory,
+    $streamFactory,
+    [
+        'app_id' => '{app-id}',
+        'app_secret' => '{app-secret}',
+        'default_graph_version' => 'v2.10',
+    ]
+);
 ```
 
 You'll need to replace the `{app-id}` and `{app-secret}` with your Facebook app's ID and secret which can be obtained from the [app settings tab](https://developers.facebook.com/apps).

--- a/docs/reference/Client.md
+++ b/docs/reference/Client.md
@@ -3,6 +3,14 @@
 The `Facebook\Client` service class juggles the dependencies needed to make requests to the Graph API.
 
 ## Facebook\Client
+```php
+public Facebook\Client __construct(
+        Psr\Http\Client\ClientInterface $client,
+        Psr\Http\Message\RequestFactoryInterface $requestFactory,
+        Psr\Http\Message\StreamFactoryInterface $streamFactory,
+        bool $enableBeta = false
+)
+```
 
 You most likely won't be working with the `Facebook\Client` service directly if you're using the `Facebook\Facebook` super service class, but if you have a highly customized environment, you might need to send requests with an instance of `Facebook\Client`.
 
@@ -16,7 +24,12 @@ $fbClient = $fb->getClient();
 Alternatively you could instantiate a new `Facebook\Client` service directly.
 
 ```php
-$fbClient = new Facebook\Client($httpClientHandler, $enableBeta = false);
+$fbClient = new Facebook\Client(
+    Psr\Http\Client\ClientInterface $client,
+    Psr\Http\Message\RequestFactoryInterface $requestFactory,
+    Psr\Http\Message\StreamFactoryInterface $streamFactory,
+    bool $enableBeta = false
+);
 ```
 
 The Graph API has a number of different base URL's based on what request you want to send. For example, if you wanted to send requests to the beta version of Graph, you'd need to send requests to [https://graph.beta.facebook.com](https://graph.beta.facebook.com) instead [https://graph.facebook.com](https://graph.facebook.com). And if you wanted to upload a video, that request would need to be sent to [https://graph-video.facebook.com](https://graph-video.facebook.com).
@@ -27,19 +40,19 @@ The `Facebook\Client` service takes the guess-work out of managing those base UR
 
 ### getHttpClientHandler()
 ```php
-public Facebook\HttpClients\HttpClientInterface getHttpClientHandler()
+public Psr\Http\Client\ClientInterface getHttpClientHandler()
 ```
 Returns the instance of `Facebook\HttpClients\HttpClientInterface` that the service is using.
 
 ### setHttpClientHandler()
 ```php
-public setHttpClientHandler(Facebook\HttpClients\HttpClientInterface $client)
+public void setHttpClientHandler(Psr\Http\Client\ClientInterface $client)
 ```
 If you've coded your own HTTP client to the `Facebook\HttpClients\HttpClientInterface`, you can inject it into the service using this method.
 
 ### enableBetaMode()
 ```php
-public enableBetaMode(boolean $enable = true)
+public void enableBetaMode(boolean $enable = true)
 ```
 Tells the service to send requests to the beta URL's which include [https://graph.beta.facebook.com](https://graph.beta.facebook.com) and [https://graph-video.beta.facebook.com](https://graph-video.beta.facebook.com).
 

--- a/docs/reference/Facebook.md
+++ b/docs/reference/Facebook.md
@@ -3,16 +3,30 @@
 The Facebook SDK for PHP is made up of many components. The `Facebook\Facebook` service class provides an easy interface for working with all the components of the SDK.
 
 ## Facebook\Facebook
+```php
+public Facebook\Facebook __construct(
+        Psr\Http\Client\ClientInterface $client,
+        Psr\Http\Message\RequestFactoryInterface $requestFactory,
+        Psr\Http\Message\StreamFactoryInterface $streamFactory,
+        array $config = []
+)
+```
 
-To instantiate a new `Facebook\Facebook` service, pass an array of configuration options to the constructor.
+To instantiate a new `Facebook\Facebook` service, pass an array of configuration options to the constructor after
+providing a PSR-18 Client and PSR-17 RequestFactory and StreamFactory.
 
 ```php
-$fb = new Facebook\Facebook([
-  'app_id' => '{app-id}',
-  'app_secret' => '{app-secret}',
-  'default_graph_version' => 'v2.10',
-  // . . .
-  ]);
+$fb = new Facebook\Facebook(
+    $client,
+    $requestFactory,
+    $streamFactory,
+    [
+        'app_id' => '{app-id}',
+        'app_secret' => '{app-secret}',
+        'default_graph_version' => 'v2.10',
+        // . . .
+    ]
+);
 ```
 
 Usage:
@@ -49,7 +63,6 @@ $fb = new Facebook\Facebook([
   'default_access_token' => '{access-token}',
   'enable_beta_mode' => true,
   'default_graph_version' => 'v2.10',
-  'http_client_handler' => 'guzzle',
   'persistent_data_handler' => 'memory',
   'url_detection_handler' => new MyUrlDetectionHandler(),
 ]);
@@ -70,23 +83,6 @@ The default fallback access token to use if one is not explicitly provided. The 
 ### `enable_beta_mode`
 Enable [beta mode](https://developers.facebook.com/docs/apps/beta-tier) so that request are made to the [https://graph.beta.facebook.com](https://graph.beta.facebook.com/) endpoint. Set to boolean `true` to enable or `false` to disable. Defaults to `false`.
 
-### `http_client_handler`
-Allows you to overwrite the default HTTP client.
-
-By default, the SDK will try to use cURL as the HTTP client. If a cURL implementation cannot be found, it will fallback to a stream wrapper HTTP client. You can force either HTTP client implementations by setting this value to `curl` or `stream`.
-
-If you wish to use Guzzle, you can set this value to `guzzle`, but it requires that you [install Guzzle](http://docs.guzzlephp.org/en/latest/) with composer.
-
-If you wish to write your own HTTP client, you can code your HTTP client to the `Facebook\HttpClients\HttpClientInterface` and set this value to an instance of your custom client.
-
-```php
-$fb = new Facebook([
-  'http_client_handler' => new MyCustomHttpClient(),
-]);
-```
-
-If any other value is provided an `InvalidArgumentException` will be thrown.
-
 ### `persistent_data_handler`
 Allows you to overwrite the default persistent data store.
 
@@ -95,9 +91,12 @@ By default, the SDK will try to use the native PHP session for the persistent da
 If you wish to write your own persistent data handler, you can code your persistent data handler to the [`Facebook\PersistentData\PersistentDataInterface`](PersistentDataInterface.md) and set the value of `persistent_data_handler` to an instance of your custom handler.
 
 ```php
-$fb = new Facebook([
-  'persistent_data_handler' => new MyCustomPersistentDataHandler(),
-]);
+$fb = new Facebook(
+    $client,
+    $requestFactory,
+    $streamFactory,
+    ['persistent_data_handler' => new MyCustomPersistentDataHandler()]
+);
 ```
 
 If any other value is provided an `InvalidArgumentException` will be thrown.
@@ -108,9 +107,12 @@ Allows you to overwrite the default URL detection logic.
 The SDK will do its best to detect the proper current URL but this can sometimes get tricky if you have a very customized environment. You can write your own URL detection logic that implements the ['Facebook\Url\UrlDetectionInterface'](UrlDetectionInterface.md)` and set the value of `url_detection_handler` to an instance of your custom URL detector.
 
 ```php
-$fb = new Facebook([
-  'url_detection_handler' => new MyUrlDetectionHandler(),
-]);
+$fb = new Facebook(
+    $client,
+    $requestFactory,
+    $streamFactory,
+    ['url_detection_handler' => new MyUrlDetectionHandler()]
+);
 ```
 
 If any other value is provided an `InvalidArgumentException` will be thrown.
@@ -122,16 +124,19 @@ The only required configuration options are `app_id`, `app_secret` and `default_
 To take advantage of this feature, simply set an environment variable named `FACEBOOK_APP_ID` with your Facebook app ID and set an environment variable named `FACEBOOK_APP_SECRET` with your Facebook app secret and you will be able to instantiate the `Facebook\Facebook` service with only needing to specify the `default_graph_version` option.
 
 ```php
-$fb = new Facebook\Facebook([
-    'default_graph_version' => 'v2.10',
-    ]);
+$fb = new Facebook\Facebook(
+    $client,
+    $requestFactory,
+    $streamFactory,
+    ['default_graph_version' => 'v2.10']
+);
 ```
 
 # Instance Methods
 
 ## getApplication()
 ```php
-public Application getApplication()
+public Facebook\Application getApplication()
 ```
 Returns the instance of `Facebook\Application` for the instantiated service.
 
@@ -167,7 +172,7 @@ Returns the default fallback [`AccessToken`](AccessToken.md) entity that is bein
 
 ## setDefaultAccessToken()
 ```php
-public setDefaultAccessToken(string|Facebook\AccessToken $accessToken)
+public void setDefaultAccessToken(string|Facebook\AccessToken $accessToken)
 ```
 Sets the default fallback access token to be use with all requests sent to Graph. The access token can be a string or an instance of [`AccessToken`](AccessToken.md).
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -218,10 +218,6 @@ class Client
         static::$requestCount++;
 
         // Prepare headers from associative array to a single string for each header.
-        $responseHeaders = [];
-        foreach ($psr7Response->getHeaders() as $name => $values) {
-            $responseHeaders[] = sprintf('%s: %s', $name, implode(", ", $values));
-        }
         $responseHeaders = $this->flattenPSR7Headers($psr7Response);
 
         $Response = new Response(

--- a/src/Client.php
+++ b/src/Client.php
@@ -255,6 +255,7 @@ class Client
     }
 
     /**
+     * @TODO Move this to the Facebook\Request class
      * Create and prepares a PSR-7 object from a Facebook\Request object to be used with a PSR-18 Client
      * @param Request $facebookRequest
      * @return RequestInterface

--- a/src/Client.php
+++ b/src/Client.php
@@ -78,7 +78,7 @@ class Client
     /**
      * @var ClientInterface HTTP client handler
      */
-    protected $httpClient;
+    private $httpClient;
 
     /**
      * @var RequestFactoryInterface
@@ -113,26 +113,6 @@ class Client
         $this->enableBetaMode = $enableBeta;
         $this->requestFactory = $requestFactory;
         $this->streamFactory = $streamFactory;
-    }
-
-    /**
-     * Sets the HTTP client handler.
-     *
-     * @param ClientInterface $httpClient
-     */
-    public function setHttpClient(ClientInterface $httpClient)
-    {
-        $this->httpClient = $httpClient;
-    }
-
-    /**
-     * Returns the HTTP client handler.
-     *
-     * @return ClientInterface
-     */
-    public function getHttpClient()
-    {
-        return $this->httpClient;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -23,6 +23,7 @@
 namespace Facebook;
 
 use Facebook\Exception\SDKException;
+use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -199,9 +200,10 @@ class Client
      *
      * @param Request $request
      *
-     * @throws SDKException
-     *
      * @return Response
+     * @throws ClientExceptionInterface
+     *
+     * @throws SDKException
      */
     public function sendRequest(Request $request)
     {
@@ -239,9 +241,10 @@ class Client
      *
      * @param BatchRequest $request
      *
-     * @throws SDKException
-     *
      * @return BatchResponse
+     * @throws ClientExceptionInterface
+     *
+     * @throws SDKException
      */
     public function sendBatchRequest(BatchRequest $request)
     {
@@ -251,6 +254,11 @@ class Client
         return new BatchResponse($request, $Response);
     }
 
+    /**
+     * Create and prepares a PSR-7 object from a Facebook\Request object to be used with a PSR-18 Client
+     * @param Request $facebookRequest
+     * @return RequestInterface
+     */
     private function createPSR7RequestFromFacebookRequest(Request $facebookRequest): RequestInterface
     {
         $postToVideoUrl = $facebookRequest->containsVideoUploads();
@@ -276,16 +284,18 @@ class Client
         return $psrRequest->withBody($bodyStream);
     }
 
+    /**
+     * Flatten PSR-7 headers such they can be added to a Facebook\Response|Facebook\Request
+     * @param MessageInterface $psr7Message
+     * @param array $initialValues
+     * @return array
+     */
     private function flattenPSR7Headers(MessageInterface $psr7Message, array $initialValues = []): array
     {
         $flattenedHeaders = array_map(
             function ($value) { return implode(', ', $value); },
             $psr7Message->getHeaders()
         );
-        /* Old Implementation taken from sendRequest()
-        foreach ($psr7Message->getHeaders() as $name => $values) {
-            $initialValues[$name] = implode(", ", $values);
-        }*/
         return array_merge($initialValues, $flattenedHeaders);
     }
 }

--- a/tests/Authentication/OAuth2ClientTest.php
+++ b/tests/Authentication/OAuth2ClientTest.php
@@ -27,7 +27,10 @@ use Facebook\Application;
 use Facebook\Authentication\OAuth2Client;
 use Facebook\Authentication\AccessTokenMetadata;
 use Facebook\Authentication\AccessToken;
+use Http\Factory\Guzzle\RequestFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use PHPUnit\Framework\TestCase;
+use RicardoFiorani\GuzzlePsr18Adapter\Client;
 
 class OAuth2ClientTest extends TestCase
 {
@@ -50,7 +53,7 @@ class OAuth2ClientTest extends TestCase
     protected function setUp()
     {
         $app = new Application('123', 'foo_secret');
-        $this->client = new FooClientForOAuth2Test();
+        $this->client = new FooClientForOAuth2Test(new Client(), new RequestFactory(), new StreamFactory());
         $this->oauth = new OAuth2Client($app, $this->client, static::TESTING_GRAPH_VERSION);
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -70,23 +70,6 @@ class ClientTest extends TestCase
         $this->fbClient = new Client(new MyFooHttpClient(), new RequestFactory(), new StreamFactory());
     }
 
-    public function testACustomHttpClientCanBeInjected()
-    {
-        $handler = new MyFooHttpClient();
-        $client = new Client($handler, new RequestFactory(), new StreamFactory());
-        $httpClient = $client->getHttpClient();
-
-        $this->assertInstanceOf(MyFooHttpClient::class, $httpClient);
-    }
-/*
-    public function testTheHttpClientWillFallbackToDefault()
-    {
-        $client = new Client();
-        $httpClient = $client->getHttpClient();
-
-        $this->assertInstanceOf(HttpClient::class, $httpClient);
-    }
-*/
     public function testBetaModeCanBeDisabledOrEnabledViaConstructor()
     {
         $client = new Client(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), false);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -30,12 +30,16 @@ use Facebook\Client;
 use Facebook\FileUpload\File;
 use Facebook\FileUpload\Video;
 // These are needed when you uncomment the HTTP clients below.
+use Facebook\Tests\Fixtures\FakeGraphApiForResumableUpload;
+use Facebook\Tests\Fixtures\FooHttpClientInterface;
 use Facebook\Tests\Fixtures\MyFooBatchHttpClient;
 use Facebook\Tests\Fixtures\MyFooHttpClient;
 use Facebook\Response;
 use Facebook\BatchResponse;
 use Facebook\GraphNode\GraphNode;
-use Http\Client\HttpClient;
+
+use Http\Factory\Guzzle\RequestFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use PHPUnit\Framework\TestCase;
 
 class ClientTest extends TestCase
@@ -63,18 +67,18 @@ class ClientTest extends TestCase
     protected function setUp()
     {
         $this->fbApp = new Application('id', 'shhhh!');
-        $this->fbClient = new Client(new MyFooHttpClient());
+        $this->fbClient = new Client(new MyFooHttpClient(), new RequestFactory(), new StreamFactory());
     }
 
     public function testACustomHttpClientCanBeInjected()
     {
         $handler = new MyFooHttpClient();
-        $client = new Client($handler);
+        $client = new Client($handler, new RequestFactory(), new StreamFactory());
         $httpClient = $client->getHttpClient();
 
         $this->assertInstanceOf(MyFooHttpClient::class, $httpClient);
     }
-
+/*
     public function testTheHttpClientWillFallbackToDefault()
     {
         $client = new Client();
@@ -82,21 +86,21 @@ class ClientTest extends TestCase
 
         $this->assertInstanceOf(HttpClient::class, $httpClient);
     }
-
+*/
     public function testBetaModeCanBeDisabledOrEnabledViaConstructor()
     {
-        $client = new Client(null, false);
+        $client = new Client(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), false);
         $url = $client->getBaseGraphUrl();
         $this->assertEquals(Client::BASE_GRAPH_URL, $url);
 
-        $client = new Client(null, true);
+        $client = new Client(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), true);
         $url = $client->getBaseGraphUrl();
         $this->assertEquals(Client::BASE_GRAPH_URL_BETA, $url);
     }
 
     public function testBetaModeCanBeDisabledOrEnabledViaMethod()
     {
-        $client = new Client();
+        $client = new Client(new MyFooHttpClient(), new RequestFactory(), new StreamFactory());
         $client->enableBetaMode(false);
         $url = $client->getBaseGraphUrl();
         $this->assertEquals(Client::BASE_GRAPH_URL, $url);
@@ -108,7 +112,7 @@ class ClientTest extends TestCase
 
     public function testGraphVideoUrlCanBeSet()
     {
-        $client = new Client();
+        $client = new Client(new MyFooHttpClient(), new RequestFactory(), new StreamFactory());
         $client->enableBetaMode(false);
         $url = $client->getBaseGraphUrl($postToVideoUrl = true);
         $this->assertEquals(Client::BASE_GRAPH_VIDEO_URL, $url);
@@ -136,7 +140,7 @@ class ClientTest extends TestCase
         ];
         $fbBatchRequest = new BatchRequest($this->fbApp, $fbRequests);
 
-        $fbBatchClient = new Client(new MyFooBatchHttpClient());
+        $fbBatchClient = new Client(new MyFooBatchHttpClient(), new RequestFactory(), new StreamFactory());
         $response = $fbBatchClient->sendBatchRequest($fbBatchRequest);
 
         $this->assertInstanceOf(BatchResponse::class, $response);
@@ -274,6 +278,6 @@ class ClientTest extends TestCase
             TestCredentials::$appSecret
         );
 
-        static::$testClient = new Client();
+        static::$testClient = new Client(new \RicardoFiorani\GuzzlePsr18Adapter\Client(), new RequestFactory(), new StreamFactory());
     }
 }

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -31,13 +31,13 @@ use Facebook\Tests\Fixtures\FakeGraphApiForResumableUpload;
 use Facebook\Tests\Fixtures\FooHttpClientInterface;
 use Facebook\Tests\Fixtures\FooPersistentDataInterface;
 use Facebook\Tests\Fixtures\FooUrlDetectionInterface;
-use Facebook\HttpClients\CurlHttpClient;
-use Facebook\HttpClients\StreamHttpClient;
-use Facebook\HttpClients\GuzzleHttpClient;
 use Facebook\PersistentData\InMemoryPersistentDataHandler;
+use Facebook\Tests\Fixtures\MyFooHttpClient;
 use Facebook\Url\UrlDetectionHandler;
 use Facebook\Response;
 use Facebook\GraphNode\GraphUser;
+use Http\Factory\Guzzle\RequestFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use PHPUnit\Framework\Error\Error;
 use PHPUnit\Framework\TestCase;
 
@@ -60,7 +60,7 @@ class Test extends TestCase
             'app_secret' => 'foo_secret',
             'default_graph_version' => 'v0.0',
         ];
-        new Facebook($config);
+        new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $config);
     }
 
     /**
@@ -74,7 +74,7 @@ class Test extends TestCase
             'app_id' => 'foo_id',
             'default_graph_version' => 'v0.0',
         ];
-        new Facebook($config);
+        new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $config);
     }
 
     /**
@@ -86,30 +86,9 @@ class Test extends TestCase
             'app_id' => 'foo_id',
             'app_secret' => 'foo_secret',
         ];
-        new Facebook($config);
+        new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $config);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testSettingAnInvalidHttpClientTypeThrows()
-    {
-        $config = array_merge($this->config, [
-            'http_client' => 'foo_client',
-        ]);
-        new Facebook($config);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testSettingAnInvalidHttpClientClassThrows()
-    {
-        $config = array_merge($this->config, [
-            'http_client' => new \stdClass(),
-        ]);
-        new Facebook($config);
-    }
     /**
      * @expectedException \InvalidArgumentException
      */
@@ -118,7 +97,7 @@ class Test extends TestCase
         $config = array_merge($this->config, [
             'persistent_data_handler' => 'foo_handler',
         ]);
-        new Facebook($config);
+        new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $config);
     }
 
     public function testPersistentDataHandlerCanBeForced()
@@ -126,7 +105,7 @@ class Test extends TestCase
         $config = array_merge($this->config, [
             'persistent_data_handler' => 'memory'
         ]);
-        $fb = new Facebook($config);
+        $fb = new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $config);
         $this->assertInstanceOf(
             InMemoryPersistentDataHandler::class,
             $fb->getRedirectLoginHelper()->getPersistentDataHandler()
@@ -141,18 +120,18 @@ class Test extends TestCase
         $config = array_merge($this->config, [
             'url_detection_handler' => 'foo_handler',
         ]);
-        new Facebook($config);
+        new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $config);
     }
 
     public function testTheUrlHandlerWillDefaultToTheImplementation()
     {
-        $fb = new Facebook($this->config);
+        $fb = new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $this->config);
         $this->assertInstanceOf(UrlDetectionHandler::class, $fb->getUrlDetectionHandler());
     }
 
     public function testAnAccessTokenCanBeSetAsAString()
     {
-        $fb = new Facebook($this->config);
+        $fb = new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $this->config);
         $fb->setDefaultAccessToken('foo_token');
         $accessToken = $fb->getDefaultAccessToken();
 
@@ -162,7 +141,7 @@ class Test extends TestCase
 
     public function testAnAccessTokenCanBeSetAsAnAccessTokenEntity()
     {
-        $fb = new Facebook($this->config);
+        $fb = new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $this->config);
         $fb->setDefaultAccessToken(new AccessToken('bar_token'));
         $accessToken = $fb->getDefaultAccessToken();
 
@@ -178,7 +157,7 @@ class Test extends TestCase
         $config = array_merge($this->config, [
             'default_access_token' => 123,
         ]);
-        new Facebook($config);
+        new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $config);
     }
 
     public function testCreatingANewRequestWillDefaultToTheProperConfig()
@@ -188,7 +167,7 @@ class Test extends TestCase
             'enable_beta_mode' => true,
             'default_graph_version' => 'v1337',
         ]);
-        $fb = new Facebook($config);
+        $fb = new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $config);
 
         $request = $fb->request('FOO_VERB', '/foo');
         $this->assertEquals('1337', $request->getApplication()->getId());
@@ -208,7 +187,7 @@ class Test extends TestCase
             'enable_beta_mode' => true,
             'default_graph_version' => 'v1337',
         ]);
-        $fb = new Facebook($config);
+        $fb = new Facebook(new MyFooHttpClient(), new RequestFactory(), new StreamFactory(), $config);
 
         $batchRequest = $fb->newBatchRequest();
         $this->assertEquals('1337', $batchRequest->getApplication()->getId());
@@ -226,11 +205,10 @@ class Test extends TestCase
     public function testCanInjectCustomHandlers()
     {
         $config = array_merge($this->config, [
-            'http_client' => new FooHttpClientInterface(),
             'persistent_data_handler' => new FooPersistentDataInterface(),
             'url_detection_handler' => new FooUrlDetectionInterface(),
         ]);
-        $fb = new Facebook($config);
+        $fb = new Facebook(new FooHttpClientInterface(), new RequestFactory(), new StreamFactory(), $config);
 
         $this->assertInstanceOf(
             FooHttpClientInterface::class,
@@ -248,10 +226,7 @@ class Test extends TestCase
 
     public function testPaginationReturnsProperResponse()
     {
-        $config = array_merge($this->config, [
-            'http_client' => new FooHttpClientInterface(),
-        ]);
-        $fb = new Facebook($config);
+        $fb = new Facebook(new FooHttpClientInterface(), new RequestFactory(), new StreamFactory(), $this->config);
 
         $request = new Request($fb->getApplication(), 'foo_token', 'GET');
         $graphEdge = new GraphEdge(
@@ -283,10 +258,7 @@ class Test extends TestCase
 
     public function testCanGetSuccessfulTransferWithMaxTries()
     {
-        $config = array_merge($this->config, [
-          'http_client' => new FakeGraphApiForResumableUpload(),
-        ]);
-        $fb = new Facebook($config);
+        $fb = new Facebook(new FakeGraphApiForResumableUpload(), new RequestFactory(), new StreamFactory(), $this->config);
         $response = $fb->uploadVideo('me', __DIR__.'/foo.txt', [], 'foo-token', 3);
         $this->assertEquals([
           'video_id' => '1337',
@@ -302,10 +274,7 @@ class Test extends TestCase
         $client = new FakeGraphApiForResumableUpload();
         $client->failOnTransfer();
 
-        $config = array_merge($this->config, [
-          'http_client' => $client,
-        ]);
-        $fb = new Facebook($config);
+        $fb = new Facebook($client, new RequestFactory(), new StreamFactory(), $this->config);
         $fb->uploadVideo('4', __DIR__.'/foo.txt', [], 'foo-token', 3);
     }
 }

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -211,10 +211,6 @@ class Test extends TestCase
         $fb = new Facebook(new FooHttpClientInterface(), new RequestFactory(), new StreamFactory(), $config);
 
         $this->assertInstanceOf(
-            FooHttpClientInterface::class,
-            $fb->getClient()->getHttpClient()
-        );
-        $this->assertInstanceOf(
             FooPersistentDataInterface::class,
             $fb->getRedirectLoginHelper()->getPersistentDataHandler()
         );

--- a/tests/FileUpload/ResumableUploaderTest.php
+++ b/tests/FileUpload/ResumableUploaderTest.php
@@ -29,6 +29,8 @@ use Facebook\Client;
 use Facebook\FileUpload\ResumableUploader;
 use Facebook\FileUpload\TransferChunk;
 use Facebook\Tests\Fixtures\FakeGraphApiForResumableUpload;
+use Http\Factory\Guzzle\RequestFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use PHPUnit\Framework\TestCase;
 
 class ResumableUploaderTest extends TestCase
@@ -57,7 +59,7 @@ class ResumableUploaderTest extends TestCase
     {
         $this->fbApp = new Application('app_id', 'app_secret');
         $this->graphApi = new FakeGraphApiForResumableUpload();
-        $this->client = new Client($this->graphApi);
+        $this->client = new Client($this->graphApi, new RequestFactory(), new StreamFactory());
         $this->file = new File(__DIR__.'/../foo.txt');
     }
 

--- a/tests/Fixtures/FakeGraphApiForResumableUpload.php
+++ b/tests/Fixtures/FakeGraphApiForResumableUpload.php
@@ -24,10 +24,11 @@
 namespace Facebook\Tests\Fixtures;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
-class FakeGraphApiForResumableUpload implements HttpClient
+class FakeGraphApiForResumableUpload implements ClientInterface
 {
     public $transferCount = 0;
     private $respondWith = 'SUCCESS';
@@ -42,7 +43,7 @@ class FakeGraphApiForResumableUpload implements HttpClient
         $this->respondWith = 'FAIL_ON_TRANSFER';
     }
 
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         $body = $request->getBody()->__toString();
         // Could be start, transfer or finish

--- a/tests/Fixtures/FooHttpClientInterface.php
+++ b/tests/Fixtures/FooHttpClientInterface.php
@@ -23,12 +23,13 @@
 namespace Facebook\Tests\Fixtures;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
-class FooHttpClientInterface implements HttpClient
+class FooHttpClientInterface implements ClientInterface
 {
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         return new Response(
             1337,

--- a/tests/Fixtures/MyFooBatchHttpClient.php
+++ b/tests/Fixtures/MyFooBatchHttpClient.php
@@ -23,12 +23,13 @@
 namespace Facebook\Tests\Fixtures;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
-class MyFooBatchHttpClient implements HttpClient
+class MyFooBatchHttpClient implements ClientInterface
 {
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         return new Response(
             200,

--- a/tests/Fixtures/MyFooHttpClient.php
+++ b/tests/Fixtures/MyFooHttpClient.php
@@ -23,12 +23,13 @@
 namespace Facebook\Tests\Fixtures;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
-class MyFooHttpClient implements HttpClient
+class MyFooHttpClient implements ClientInterface
 {
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         return new Response(
             200,

--- a/tests/GraphNode/GraphEdgeTest.php
+++ b/tests/GraphNode/GraphEdgeTest.php
@@ -160,7 +160,8 @@ class GraphEdgeTest extends TestCase
     public function testTheKeysFromTheCollectionCanBeReturned()
     {
         $graphEdge = new GraphEdge(
-            $this->request, [
+            $this->request,
+            [
                 'key1' => 'foo',
                 'key2' => 'bar',
                 'key3' => 'baz',

--- a/tests/Helper/CanvasHelperTest.php
+++ b/tests/Helper/CanvasHelperTest.php
@@ -25,6 +25,8 @@ namespace Facebook\Tests\Helper;
 use Facebook\Application;
 use Facebook\Client;
 use Facebook\Helper\CanvasHelper;
+use Http\Factory\Guzzle\RequestFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use PHPUnit\Framework\TestCase;
 
 class CanvasHelperTest extends TestCase
@@ -39,7 +41,9 @@ class CanvasHelperTest extends TestCase
     protected function setUp()
     {
         $app = new Application('123', 'foo_app_secret');
-        $this->helper = new CanvasHelper($app, new Client(), 'v0.0');
+        $this->helper = new CanvasHelper($app, new Client(
+            new \RicardoFiorani\GuzzlePsr18Adapter\Client(), new RequestFactory(), new StreamFactory()
+        ), 'v0.0');
     }
 
     public function testSignedRequestDataCanBeRetrievedFromPostData()

--- a/tests/Helper/JavaScriptHelperTest.php
+++ b/tests/Helper/JavaScriptHelperTest.php
@@ -25,6 +25,8 @@ namespace Facebook\Tests\Helper;
 use Facebook\Application;
 use Facebook\Client;
 use Facebook\Helper\JavaScriptHelper;
+use Http\Factory\Guzzle\RequestFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use PHPUnit\Framework\TestCase;
 
 class JavaScriptHelperTest extends TestCase
@@ -36,7 +38,9 @@ class JavaScriptHelperTest extends TestCase
         $_COOKIE['fbsr_123'] = $this->rawSignedRequestAuthorized;
 
         $app = new Application('123', 'foo_app_secret');
-        $helper = new JavaScriptHelper($app, new Client(), 'v0.0');
+        $helper = new JavaScriptHelper($app, new Client(
+            new \RicardoFiorani\GuzzlePsr18Adapter\Client(), new RequestFactory(), new StreamFactory()
+        ), 'v0.0');
 
         $rawSignedRequest = $helper->getRawSignedRequest();
 

--- a/tests/Helper/PageTabHelperTest.php
+++ b/tests/Helper/PageTabHelperTest.php
@@ -25,6 +25,8 @@ namespace Facebook\Tests\Helper;
 use Facebook\Application;
 use Facebook\Client;
 use Facebook\Helper\PageTabHelper;
+use Http\Factory\Guzzle\RequestFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use PHPUnit\Framework\TestCase;
 
 class PageTabHelperTest extends TestCase
@@ -36,7 +38,9 @@ class PageTabHelperTest extends TestCase
         $_POST['signed_request'] = $this->rawSignedRequestAuthorized;
 
         $app = new Application('123', 'foo_app_secret');
-        $helper = new PageTabHelper($app, new Client(), 'v0.0');
+        $helper = new PageTabHelper($app, new Client(
+            new \RicardoFiorani\GuzzlePsr18Adapter\Client(), new RequestFactory(), new StreamFactory()
+        ), 'v0.0');
 
         $this->assertFalse($helper->isAdmin());
         $this->assertEquals('42', $helper->getPageId());

--- a/tests/Helper/RedirectLoginHelperTest.php
+++ b/tests/Helper/RedirectLoginHelperTest.php
@@ -28,6 +28,8 @@ use Facebook\Client;
 use Facebook\Helper\RedirectLoginHelper;
 use Facebook\PersistentData\InMemoryPersistentDataHandler;
 use Facebook\Tests\Fixtures\FooRedirectLoginOAuth2Client;
+use Http\Factory\Guzzle\RequestFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use PHPUnit\Framework\TestCase;
 
 class RedirectLoginHelperTest extends TestCase
@@ -49,7 +51,9 @@ class RedirectLoginHelperTest extends TestCase
         $this->persistentDataHandler = new InMemoryPersistentDataHandler();
 
         $app = new Application('123', 'foo_app_secret');
-        $oAuth2Client = new FooRedirectLoginOAuth2Client($app, new Client(), 'v1337');
+        $oAuth2Client = new FooRedirectLoginOAuth2Client($app, new Client(
+            new \RicardoFiorani\GuzzlePsr18Adapter\Client(), new RequestFactory(), new StreamFactory()
+        ), 'v1337');
         $this->redirectLoginHelper = new RedirectLoginHelper($oAuth2Client, $this->persistentDataHandler);
     }
 

--- a/tests/Helper/SignedRequestFromInputHelperTest.php
+++ b/tests/Helper/SignedRequestFromInputHelperTest.php
@@ -26,7 +26,10 @@ use Facebook\Application;
 use Facebook\Tests\Fixtures\FooSignedRequestHelper;
 use Facebook\Tests\Fixtures\FooSignedRequestHelperClient;
 use Facebook\Authentication\AccessToken;
+use Http\Factory\Guzzle\RequestFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use PHPUnit\Framework\TestCase;
+use RicardoFiorani\GuzzlePsr18Adapter\Client;
 
 class SignedRequestFromInputHelperTest extends TestCase
 {
@@ -42,7 +45,9 @@ class SignedRequestFromInputHelperTest extends TestCase
     protected function setUp()
     {
         $app = new Application('123', 'foo_app_secret');
-        $this->helper = new FooSignedRequestHelper($app, new FooSignedRequestHelperClient(), 'v0.0');
+        $this->helper = new FooSignedRequestHelper($app, new FooSignedRequestHelperClient(
+            new Client(), new RequestFactory(), new StreamFactory()
+        ), 'v0.0');
     }
 
     public function testSignedRequestDataCanBeRetrievedFromPostData()


### PR DESCRIPTION
Also small improvements in Facebook\Client to handle PSR-7 messages.

This also changes multiple constructors for Dependency Injection.