### PR TITLE
[6.0] Close GraphNode public API

### DIFF
--- a/src/GraphNode/Birthday.php
+++ b/src/GraphNode/Birthday.php
@@ -29,7 +29,7 @@ use DateTime;
  *
  * @package Facebook
  */
-class Birthday extends DateTime
+final class Birthday extends DateTime
 {
     /**
      * @var bool

--- a/src/GraphNode/GraphAchievement.php
+++ b/src/GraphNode/GraphAchievement.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphAchievement extends GraphNode
+final class GraphAchievement extends GraphNode
 {
     /**
      * @var array maps object key names to Graph object types

--- a/src/GraphNode/GraphAlbum.php
+++ b/src/GraphNode/GraphAlbum.php
@@ -26,7 +26,7 @@ namespace Facebook\GraphNode;
  * @package Facebook
  */
 
-class GraphAlbum extends GraphNode
+final class GraphAlbum extends GraphNode
 {
     /**
      * @var array maps object key names to Graph object types

--- a/src/GraphNode/GraphApplication.php
+++ b/src/GraphNode/GraphApplication.php
@@ -26,7 +26,7 @@ namespace Facebook\GraphNode;
  * @package Facebook
  */
 
-class GraphApplication extends GraphNode
+final class GraphApplication extends GraphNode
 {
     /**
      * Returns the ID for the application.

--- a/src/GraphNode/GraphCoverPhoto.php
+++ b/src/GraphNode/GraphCoverPhoto.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphCoverPhoto extends GraphNode
+final class GraphCoverPhoto extends GraphNode
 {
     /**
      * Returns the id of cover if it exists.

--- a/src/GraphNode/GraphEdge.php
+++ b/src/GraphNode/GraphEdge.php
@@ -29,7 +29,7 @@ use Facebook\Exception\SDKException;
 /**
  * @package Facebook
  */
-class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
+final class GraphEdge implements \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
      * @var Request the original request that generated this data

--- a/src/GraphNode/GraphEvent.php
+++ b/src/GraphNode/GraphEvent.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphEvent extends GraphNode
+final class GraphEvent extends GraphNode
 {
     /**
      * @var array maps object key names to GraphNode types

--- a/src/GraphNode/GraphGroup.php
+++ b/src/GraphNode/GraphGroup.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphGroup extends GraphNode
+final class GraphGroup extends GraphNode
 {
     /**
      * @var array maps object key names to GraphNode types

--- a/src/GraphNode/GraphLocation.php
+++ b/src/GraphNode/GraphLocation.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphLocation extends GraphNode
+final class GraphLocation extends GraphNode
 {
     /**
      * Returns the street component of the location.

--- a/src/GraphNode/GraphNode.php
+++ b/src/GraphNode/GraphNode.php
@@ -24,6 +24,7 @@ namespace Facebook\GraphNode;
 
 /**
  * @package Facebook
+ * @internal
  */
 class GraphNode
 {

--- a/src/GraphNode/GraphNodeFactory.php
+++ b/src/GraphNode/GraphNodeFactory.php
@@ -29,6 +29,7 @@ use Facebook\Exception\SDKException;
  * Class GraphNodeFactory.
  *
  * @package Facebook
+ * @internal
  *
  * ## Assumptions ##
  * GraphEdge - is ALWAYS a numeric array
@@ -39,7 +40,7 @@ use Facebook\Exception\SDKException;
  * GraphNode - MAY contain DateTime's "primitives"
  * GraphNode - MAY contain string's "primitives"
  */
-class GraphNodeFactory
+final class GraphNodeFactory
 {
     /**
      * @const string The base graph object class.

--- a/src/GraphNode/GraphPage.php
+++ b/src/GraphNode/GraphPage.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphPage extends GraphNode
+final class GraphPage extends GraphNode
 {
     /**
      * @var array maps object key names to Graph object types

--- a/src/GraphNode/GraphPicture.php
+++ b/src/GraphNode/GraphPicture.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphPicture extends GraphNode
+final class GraphPicture extends GraphNode
 {
     /**
      * Returns true if user picture is silhouette.

--- a/src/GraphNode/GraphSessionInfo.php
+++ b/src/GraphNode/GraphSessionInfo.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphSessionInfo extends GraphNode
+final class GraphSessionInfo extends GraphNode
 {
     /**
      * Returns the application id the token was issued for.

--- a/src/GraphNode/GraphUser.php
+++ b/src/GraphNode/GraphUser.php
@@ -25,7 +25,7 @@ namespace Facebook\GraphNode;
 /**
  * @package Facebook
  */
-class GraphUser extends GraphNode
+final class GraphUser extends GraphNode
 {
     /**
      * @var array maps object key names to Graph object types


### PR DESCRIPTION
Part of #447, closing the GraphNode API by making the subclasses and factory ``final`` and the GraphNode superclass as ``@internal`` which indicates that this shouldn't be extended by end users.