### PR TITLE
Fixed error with $header variable not being set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0"
+        "php": "^5.4|^7.0|^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Facebook/Url/FacebookUrlDetectionHandler.php
+++ b/src/Facebook/Url/FacebookUrlDetectionHandler.php
@@ -95,6 +95,7 @@ class FacebookUrlDetectionHandler implements UrlDetectionInterface
     protected function getHostName()
     {
         // Check for proxy first
+	$header = null;
         $header = $this->getHeader('X_FORWARDED_HOST');
         if ($header && $this->isValidForwardedHost($header)) {
             $elements = explode(',', $header);


### PR DESCRIPTION
In PHP 8 it appears that variables have to be defined. I found an issue when the $header variable was not being set and it was throwing ad error at runtime. 