### PR TITLE
Support Gaming Graph Domain

### DIFF
--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -129,6 +129,7 @@ class Facebook
             'app_secret' => getenv(static::APP_SECRET_ENV_NAME),
             'default_graph_version' => static::DEFAULT_GRAPH_VERSION,
             'enable_beta_mode' => false,
+            'use_gaming_graph' => false,
             'http_client_handler' => null,
             'persistent_data_handler' => null,
             'pseudo_random_string_generator' => null,
@@ -145,7 +146,8 @@ class Facebook
         $this->app = new FacebookApp($config['app_id'], $config['app_secret']);
         $this->client = new FacebookClient(
             HttpClientsFactory::createHttpClient($config['http_client_handler']),
-            $config['enable_beta_mode']
+            $config['enable_beta_mode'],
+            $config['use_gaming_graph']
         );
         $this->pseudoRandomStringGenerator = PseudoRandomStringGeneratorFactory::createPseudoRandomStringGenerator(
             $config['pseudo_random_string_generator']

--- a/src/Facebook/FacebookClient.php
+++ b/src/Facebook/FacebookClient.php
@@ -56,6 +56,11 @@ class FacebookClient
     const BASE_GRAPH_VIDEO_URL_BETA = 'https://graph-video.beta.facebook.com';
 
     /**
+     * @const string Gaming Graph API URL.
+     */
+    const GAMING_GRAPH_URL = 'https://graph.fb.gg';
+
+    /**
      * @const int The timeout in seconds for a normal request.
      */
     const DEFAULT_REQUEST_TIMEOUT = 60;
@@ -76,6 +81,11 @@ class FacebookClient
     protected $enableBetaMode = false;
 
     /**
+     * @var bool Toggle to use Gaming Graph url.
+     */
+    protected $useGamingGraph = false;
+
+    /**
      * @var FacebookHttpClientInterface HTTP client handler.
      */
     protected $httpClientHandler;
@@ -91,10 +101,11 @@ class FacebookClient
      * @param FacebookHttpClientInterface|null $httpClientHandler
      * @param boolean                          $enableBeta
      */
-    public function __construct(FacebookHttpClientInterface $httpClientHandler = null, $enableBeta = false)
+    public function __construct(FacebookHttpClientInterface $httpClientHandler = null, $enableBeta = false, $useGamingGraph = false)
     {
         $this->httpClientHandler = $httpClientHandler ?: $this->detectHttpClientHandler();
         $this->enableBetaMode = $enableBeta;
+        $this->useGamingGraph = $useGamingGraph;
     }
 
     /**
@@ -148,6 +159,10 @@ class FacebookClient
     {
         if ($postToVideoUrl) {
             return $this->enableBetaMode ? static::BASE_GRAPH_VIDEO_URL_BETA : static::BASE_GRAPH_VIDEO_URL;
+        }
+
+        if ($this->useGamingGraph) {
+            return static::GAMING_GRAPH_URL;
         }
 
         return $this->enableBetaMode ? static::BASE_GRAPH_URL_BETA : static::BASE_GRAPH_URL;

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -416,4 +416,24 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $fb = new Facebook($config);
         $fb->uploadVideo('4', __DIR__.'/foo.txt', [], 'foo-token', 3);
     }
+
+    public function testCreatingANewRequestWithGamingGraphDomain()
+    {
+        $config = array_merge($this->config, [
+            'app_id' => FacebookTestCredentials::$appId,
+            'app_secret' => FacebookTestCredentials::$appSecret,
+            'use_gaming_graph' => true,
+        ]);
+        $fb = new Facebook($config);
+
+        $oauth = $fb->getOAuth2Client();
+        $metadata = $oauth->debugToken('baz_token');
+
+        $this->assertInstanceOf('Facebook\Authentication\AccessTokenMetadata', $metadata);
+
+        $request = $oauth->getLastRequest();
+        $this->assertEquals('GET', $request->getMethod());
+        $this->assertEquals('/debug_token', $request->getEndpoint());
+        $this->assertEquals(Facebook::DEFAULT_GRAPH_VERSION, $request->getGraphVersion());
+    }
 }


### PR DESCRIPTION
If APP client use the SDK of Gaming Graph Domain, APP server have to request the URL of Gaming Graph Domain, or add 'GG|' in front APP_ID at Facebook\FacebookApp@getAccessToken.
This PR privode a simple way to toggle to use Gaming Graph URL.
Reference [Gaming Graph Domain (graph.fb.gg)](https://developers.facebook.com/docs/games/gaming-services/domain/)
